### PR TITLE
Adds cyborg self-renaming at roundstart.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -330,6 +330,10 @@ Turf and target are seperate in case you want to teleport some distance from a t
 					A.aiPDA.owner = newname
 					A.aiPDA.name = newname + " (" + A.aiPDA.ownjob + ")"
 
+		if(cmptext("cyborg",role))
+			if(isrobot(src))
+				var/mob/living/silicon/robot/A = src
+				A.custom_name = newname
 
 		fully_replace_character_name(oldname,newname)
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -98,6 +98,8 @@
 	var/revival_cloning = 1
 	var/revival_brain_life = -1
 
+	var/rename_cyborg = 1
+
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
 	var/run_speed = 0
@@ -277,6 +279,8 @@
 					config.revival_cloning			= text2num(value)
 				if("revival_brain_life")
 					config.revival_brain_life		= text2num(value)
+				if("rename_cyborg")
+					config.rename_cyborg			= text2num(value)
 				if("run_delay")
 					config.run_speed				= text2num(value)
 				if("walk_delay")

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -53,6 +53,7 @@
 	if(..()) return 0
 	R.name = heldname
 	R.real_name = heldname
+	R.custom_name = heldname //Required or else if the cyborg's module changes, their name is lost.
 
 	return 1
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -282,6 +282,10 @@
 
 	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot( loc )
 
+	if (!config.rename_cyborg)
+	else
+		O.rename_self("cyborg", 1)
+
 	// cyborgs produced by Robotize get an automatic power cell
 	O.cell = new(O)
 	O.cell.maxcharge = 7500

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -18,6 +18,10 @@ REVIVAL_CLONING 1
 # amount of time (in hundredths of seconds) for which a brain retains the "spark of life" after the person's death (set to -1 for infinite)
 REVIVAL_BRAIN_LIFE -1
 
+### RENAMING ###
+
+# Whether cyborgs can rename themselves at roundstart or when built.  Has no effect on roboticists renaming cyborgs the normal way.  Set to 0 to disable self-renaming.
+RENAME_CYBORG 1
 
 ### MOB MOVEMENT ###
 


### PR DESCRIPTION
- Cyborgs can now rename themselves when created, like the AI, clown. mime, etc.
- Adds a config option so the server host can disable this if they want to.
- Fixes a bug where, if you were renamed using a renaming board, then changed your module, you lost your new name.

~~Added myself to admins.txt because github's annoying and it doesn't really matter anyways.~~ I guess that didn't get in somehow.

Not sure if borgs made after roundstart are renamed or not since I couldn't test it alone.

Here's a picture.
http://puu.sh/7yFCn.png

I'll make a changelog if this gets merged.
