### PR TITLE
Assistant Registration [Ready to Merge]

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -9,6 +9,7 @@
 	selection_color = "#dddddd"
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
+	idtype = /obj/item/weapon/card/id/assistant
 
 /datum/job/assistant/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -11,6 +11,7 @@
 	req_admin_notify = 1
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
+	assistant_access = list(access_heads)
 	minimal_player_age = 14
 
 

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -68,7 +68,7 @@
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
-
+	assistant_access = list(access_heads)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -10,7 +10,7 @@
 	selection_color = "#dddddd"
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_mineral_storeroom)
 	minimal_access = list(access_bar, access_mineral_storeroom)
-
+	assistant_access = list(access_bar)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -51,7 +51,7 @@
 	selection_color = "#dddddd"
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue)
 	minimal_access = list(access_kitchen, access_morgue)
-
+	assistant_access = list(access_kitchen)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -76,7 +76,7 @@
 	selection_color = "#dddddd"
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
-
+	assistant_access = list(access_hydroponics)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -103,7 +103,7 @@
 	selection_color = "#dddddd"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
-
+	assistant_access = list(access_cargo)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -128,7 +128,7 @@
 	selection_color = "#dddddd"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
-
+	assistant_access = list(access_cargo)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -151,7 +151,7 @@
 	selection_color = "#dddddd"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
-
+	assistant_access = list(access_mining)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -186,7 +186,7 @@
 	selection_color = "#dddddd"
 	access = list(access_theatre, access_maint_tunnels)
 	minimal_access = list(access_theatre)
-
+	assistant_access = list(access_theatre)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -219,7 +219,7 @@
 	selection_color = "#dddddd"
 	access = list(access_theatre, access_maint_tunnels)
 	minimal_access = list(access_theatre)
-
+	assistant_access = list(access_theatre)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -260,7 +260,7 @@
 	selection_color = "#dddddd"
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)
-
+	assistant_access = list(access_janitor)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -284,7 +284,7 @@
 	selection_color = "#dddddd"
 	access = list(access_library, access_maint_tunnels)
 	minimal_access = list(access_library)
-
+	assistant_access = list(access_library)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -311,7 +311,7 @@ var/global/lawyer = 0//Checks for another lawyer
 	selection_color = "#dddddd"
 	access = list(access_lawyer, access_court, access_sec_doors, access_maint_tunnels)
 	minimal_access = list(access_lawyer, access_court, access_sec_doors)
-
+	assistant_access = list(access_lawyer)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -10,6 +10,7 @@
 	selection_color = "#dddddd"
 	access = list(access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels)
 	minimal_access = list(access_morgue, access_chapel_office, access_crematorium)
+	assistant_access = list(access_chapel_office)
 
 	//Pretty bible names
 	var/global/list/biblenames =		list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon")

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -17,6 +17,7 @@
 			            access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_mineral_storeroom)
+	assistant_access = list(access_engine,access_maint_tunnels)
 	minimal_player_age = 7
 
 
@@ -50,8 +51,7 @@
 	selection_color = "#fff5cc"
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_tcomsat)
 	minimal_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_tcomsat)
-
-
+	assistant_access = list(access_engine,access_maint_tunnels)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -83,7 +83,7 @@
 	selection_color = "#fff5cc"
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction)
-
+	assistant_access = list(access_atmospherics,access_maint_tunnels)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -7,6 +7,9 @@
 	var/list/minimal_access = list()		//Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
 	var/list/access = list()				//Useful for servers which either have fewer players, so each person needs to fill more than one role, or servers which like to give more access, so players can't hide forever in their super secure departments (I'm looking at you, chemistry!)
 
+	//Assistant acess : acess granted to job's assistants
+	var/list/assistant_access = list()
+
 	//Bitflags for the job
 	var/flag = 0
 	var/department_flag = 0

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -15,6 +15,7 @@
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors)
+	assistant_access = list(access_medical)
 	minimal_player_age = 7
 
 	equip(var/mob/living/carbon/human/H)
@@ -47,7 +48,7 @@
 	selection_color = "#ffeef0"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
 	minimal_access = list(access_medical, access_morgue, access_surgery)
-
+	assistant_access = list(access_medical)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -80,7 +81,7 @@
 	selection_color = "#ffeef0"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_chemistry, access_mineral_storeroom)
-
+	assistant_access = list(access_medical)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -104,7 +105,7 @@
 	selection_color = "#ffeef0"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_research)
-
+	assistant_access = list(access_medical)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -129,7 +130,7 @@
 	selection_color = "#ffeef0"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_virology, access_mineral_storeroom)
-
+	assistant_access = list(access_medical)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -19,6 +19,7 @@
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom,
 			            access_tech_storage)
+	assistant_access = list(access_research)
 	minimal_player_age = 7
 
 	equip(var/mob/living/carbon/human/H)
@@ -45,7 +46,7 @@
 	selection_color = "#ffeeff"
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_mineral_storeroom)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobiology, access_mineral_storeroom)
-
+	assistant_access = list(access_research)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
@@ -71,6 +72,7 @@
 	selection_color = "#ffeeff"
 	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	assistant_access = list(access_robotics)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -23,6 +23,7 @@
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
+	assistant_access = list(access_sec_doors)
 	minimal_player_age = 14
 
 	equip(var/mob/living/carbon/human/H)
@@ -63,6 +64,7 @@
 	selection_color = "#ffeeee"
 	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_armory, access_court) //But see /datum/job/warden/get_access()
+	assistant_access = list(access_sec_doors)
 	minimal_player_age = 7
 
 	equip(var/mob/living/carbon/human/H)
@@ -106,6 +108,7 @@
 	selection_color = "#ffeeee"
 	access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
 	minimal_access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
+	assistant_access = list(access_sec_doors)
 	minimal_player_age = 7
 
 
@@ -152,6 +155,7 @@
 	selection_color = "#ffeeee"
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_court) //But see /datum/job/warden/get_access()
+	assistant_access = list(access_sec_doors)
 	minimal_player_age = 7
 	var/list/dep_access = null
 
@@ -186,7 +190,7 @@
 	L |= ..() | check_config_for_sec_maint()
 	dep_access = null;
 	return L
-	
+
 var/list/sec_departments = list("engineering", "supply", "medical", "science")
 
 /datum/job/officer/proc/assign_sec_to_department(var/mob/living/carbon/human/H)
@@ -236,7 +240,7 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 					break
 		H << "<b>You have been assigned to [department]!</b>"
 		return
-	
+
 /obj/item/device/radio/headset/headset_sec/department/New()
 	wires = new(src)
 	secure_radio_connections = new

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -227,6 +227,12 @@
 
 			var/jobs = "<span id='alljobsslot'><a href='#' onclick='showAll()'>[target_rank]</a></span>" //CHECK THIS
 
+			if(istype(modify,/obj/item/weapon/card/id/assistant))
+				var/obj/item/weapon/card/id/assistant/card  = modify
+				if(card.registered)
+					jobs += "<a href=?src=\ref[src];choice=reset_registration>Reset Registration</a>" //Keeping it consistent with the rest
+
+
 			var/accesses = ""
 			if(istype(src,/obj/machinery/computer/card/centcom))
 				accesses += "<h5>Central Command:</h5>"
@@ -407,6 +413,11 @@
 				P.info = t1
 				P.name = "paper- 'Crew Manifest'"
 				printing = null
+		if ("reset_registration")
+			if (authenticated)
+				var/obj/item/weapon/card/id/assistant/card = modify
+				card.ResetRegistration()
+
 	if (modify)
 		modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
 	updateUsrDialog()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -210,20 +210,27 @@
 	var/registered = FALSE
 
 /obj/item/weapon/card/id/assistant/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/card/id) && !registered)
-		var/obj/item/weapon/card/id/idcard = I
-		desc = "Assistant to [idcard.registered_name]."
+	if(!registered)
+		var/obj/item/weapon/card/id/idcard = I.GetID()
+		if(idcard)
+			desc = "Assistant to [idcard.registered_name]."
 
-		var/datum/job/job = null
-		for(var/datum/job/J in job_master.occupations)
-			if(J.title == idcard.assignment)
-				job = J
-				break
+			var/datum/job/job = null
+			for(var/datum/job/J in job_master.occupations)
+				if(J.title == idcard.assignment)
+					job = J
+					break
 
-		access |= job.assistant_access
-		registered = TRUE
-		user << "<span class='notice'>You register the assistant as a part of your department.</span>"
+			access |= job.assistant_access
+			registered = TRUE
+			user << "<span class='notice'>You register the assistant as a part of your department.</span>"
 
 /obj/item/weapon/card/id/assistant/attack_self(mob/user)	//copypasta but not worth proc imo
 	user.visible_message("[user] shows \his [src]: \icon[src] [name]: assignment: [registered ? desc : assignment]")
+
+/obj/item/weapon/card/id/assistant/proc/ResetRegistration()
+	src.registered = FALSE
+	src.desc = "Imprinted with the Assistant Lifelong Enslavement Contract."
+	var/datum/job/assdatum = job_master.GetJob("Assistant")
+	src.access = assdatum.get_access()
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -54,8 +54,8 @@
  * ID CARDS
  */
 /obj/item/weapon/card/emag
-	desc = "It's a card with a magnetic strip attached to some circuitry."
 	name = "cryptographic sequencer"
+	desc = "It's a card with a magnetic strip attached to some circuitry."
 	icon_state = "emag"
 	item_state = "card-id"
 	origin_tech = "magnets=2;syndicate=2"
@@ -65,22 +65,18 @@
 	desc = "A card used to provide ID and determine access across the station."
 	icon_state = "id"
 	item_state = "card-id"
-	var/mining_points = 0 //For redeeming at mining equipment lockers
-	var/access = list()
-	var/registered_name = null // The name registered_name on the card
 	slot_flags = SLOT_ID
-
+	var/mining_points = 0		//For redeeming at mining equipment lockers
+	var/access = list()
+	var/registered_name = null	//The name registered_name on the card
 	var/assignment = null
-	var/dorm = 0		// determines if this ID has claimed a dorm already
 
-/obj/item/weapon/card/id/attack_self(mob/user as mob)
-	for(var/mob/O in viewers(user, null))
-		O.show_message(text("[] shows you: \icon[] []: assignment: []", user, src, src.name, src.assignment), 1)
-	src.add_fingerprint(user)
-	return
+/obj/item/weapon/card/id/attack_self(mob/user)
+	user.visible_message("[user] shows \his [src]: \icon[src] [name]: assignment: [assignment]")
 
 /obj/item/weapon/card/id/examine()
 	..()
+	usr << "The current assignment on the card is [assignment]."
 	if(mining_points)
 		usr << "There's [mining_points] mining equipment redemption points loaded onto this card."
 
@@ -89,14 +85,6 @@
 
 /obj/item/weapon/card/id/GetID()
 	return src
-
-/obj/item/weapon/card/id/verb/read()
-	set name = "Read ID Card"
-	set category = "Object"
-	set src in usr
-
-	usr << text("\icon[] []: The current assignment on the card is [].", src, src.name, src.assignment)
-	return
 
 
 /obj/item/weapon/card/id/silver
@@ -116,33 +104,33 @@
 	access = list(access_maint_tunnels, access_syndicate)
 	origin_tech = "syndicate=3"
 
-/obj/item/weapon/card/id/syndicate/afterattack(var/obj/item/weapon/O as obj, mob/user as mob, proximity)
-	if(!proximity) return
-	if(istype(O, /obj/item/weapon/card/id))
-		var/obj/item/weapon/card/id/I = O
-		src.access |= I.access
-		if(istype(user, /mob/living) && user.mind)
+/obj/item/weapon/card/id/syndicate/afterattack(obj/item/I, mob/user, proximity)
+	if(!proximity)	return
+	if(istype(I, /obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/idcard = I
+		access |= idcard.access
+		if(isliving(user) && user.mind)
 			if(user.mind.special_role)
-				usr << "\blue The card's microscanners activate as you pass it over the ID, copying its access."
+				user << "<span class='notice'>The card's microscanners activate as you pass it over the ID, copying its access.</span>"
 
 
-/obj/item/weapon/card/id/syndicate/attack_self(mob/user as mob)
+/obj/item/weapon/card/id/syndicate/attack_self(mob/user)
 	if(!src.registered_name)
 		//Stop giving the players unsanitized unputs! You are giving ways for players to intentionally crash clients! -Nodrak
 		var t = copytext(sanitize(input(user, "What name would you like to put on this card?", "Agent card name", ishuman(user) ? user.real_name : user.name)),1,26)
 		if(!t || t == "Unknown" || t == "floor" || t == "wall" || t == "r-wall") //Same as mob/new_player/prefrences.dm
 			alert("Invalid name.")
 			return
-		src.registered_name = t
+		registered_name = t
 
-		var u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant")),1,MAX_MESSAGE_LEN)
+		var u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than maintenance.", "Agent card job assignment", "Assistant")),1,MAX_MESSAGE_LEN)
 		if(!u)
 			alert("Invalid assignment.")
-			src.registered_name = ""
+			registered_name = ""
 			return
-		src.assignment = u
-		src.name = "[src.registered_name]'s ID Card ([src.assignment])"
-		user << "\blue You successfully forge the ID card."
+		assignment = u
+		name = "[src.registered_name]'s ID Card ([src.assignment])"
+		user << "<span class='notice'>You successfully forge the ID card.</span>"
 	else
 		..()
 
@@ -182,63 +170,60 @@
 	item_state = "orange-id"
 	assignment = "Prisoner"
 	registered_name = "Scum"
-	var/goal = 0 //How far from freedom?
+	var/goal = 0	//How far from freedom?
 	var/points = 0
 
-/obj/item/weapon/card/id/prisoner/attack_self(mob/user as mob)
+/obj/item/weapon/card/id/prisoner/attack_self(mob/user)
 	usr << "You have accumulated [points] out of the [goal] points you need for freedom."
 
 /obj/item/weapon/card/id/prisoner/one
-	name = "Prisoner #13-001"
+	name = "prisoner card #13-001"
 	registered_name = "Prisoner #13-001"
 
 /obj/item/weapon/card/id/prisoner/two
-	name = "Prisoner #13-002"
+	name = "prisoner card #13-002"
 	registered_name = "Prisoner #13-002"
 
 /obj/item/weapon/card/id/prisoner/three
-	name = "Prisoner #13-003"
+	name = "prisoner card #13-003"
 	registered_name = "Prisoner #13-003"
 
 /obj/item/weapon/card/id/prisoner/four
-	name = "Prisoner #13-004"
+	name = "prisoner card #13-004"
 	registered_name = "Prisoner #13-004"
 
 /obj/item/weapon/card/id/prisoner/five
-	name = "Prisoner #13-005"
+	name = "prisoner card #13-005"
 	registered_name = "Prisoner #13-005"
 
 /obj/item/weapon/card/id/prisoner/six
-	name = "Prisoner #13-006"
+	name = "prisoner card #13-006"
 	registered_name = "Prisoner #13-006"
 
 /obj/item/weapon/card/id/prisoner/seven
-	name = "Prisoner #13-007"
+	name = "prisoner card #13-007"
 	registered_name = "Prisoner #13-007"
 
 /obj/item/weapon/card/id/assistant
-	name = "Assistant employment card"
-	desc = "Imprinted with Assitant Lifelong Enslavement Contract"
-	var/registered  = 0
+	name = "assistant employment card"
+	desc = "Imprinted with the Assistant Lifelong Enslavement Contract."
+	var/registered = FALSE
 
-/obj/item/weapon/card/id/assistant/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weapon/card/id) && !registered)
-		var/obj/item/weapon/card/id/I = W
-		src.desc = "Assistant to [I.registered_name]"
+/obj/item/weapon/card/id/assistant/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/weapon/card/id) && !registered)
+		var/obj/item/weapon/card/id/idcard = I
+		desc = "Assistant to [idcard.registered_name]."
 
 		var/datum/job/job = null
 		for(var/datum/job/J in job_master.occupations)
-			if(J.title == I.assignment)
+			if(J.title == idcard.assignment)
 				job = J
 				break
 
-		src.access |= job.assistant_access
-		src.registered = 1
-		user << "You register the assistant"
+		access |= job.assistant_access
+		registered = TRUE
+		user << "<span class='notice'>You register the assistant as a part of your department.</span>"
 
-/obj/item/weapon/card/id/assistant/attack_self(mob/user as mob) // copypasta but not worth proc imo
-	for(var/mob/O in viewers(user, null))
-		O.show_message(text("[] shows you: \icon[] []: assignment: []", user, src, src.name, registered? src.desc : src.assignment), 1)
-	src.add_fingerprint(user)
-	return
+/obj/item/weapon/card/id/assistant/attack_self(mob/user)	//copypasta but not worth proc imo
+	user.visible_message("[user] shows \his [src]: \icon[src] [name]: assignment: [registered ? desc : assignment]")
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -215,3 +215,30 @@
 /obj/item/weapon/card/id/prisoner/seven
 	name = "Prisoner #13-007"
 	registered_name = "Prisoner #13-007"
+
+/obj/item/weapon/card/id/assistant
+	name = "Assistant employment card"
+	desc = "Imprinted with Assitant Lifelong Enslavement Contract"
+	var/registered  = 0
+
+/obj/item/weapon/card/id/assistant/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/card/id) && !registered)
+		var/obj/item/weapon/card/id/I = W
+		src.desc = "Assistant to [I.registered_name]"
+
+		var/datum/job/job = null
+		for(var/datum/job/J in job_master.occupations)
+			if(J.title == I.assignment)
+				job = J
+				break
+
+		src.access |= job.assistant_access
+		src.registered = 1
+		user << "You register the assistant"
+
+/obj/item/weapon/card/id/assistant/attack_self(mob/user as mob) // copypasta but not worth proc imo
+	for(var/mob/O in viewers(user, null))
+		O.show_message(text("[] shows you: \icon[] []: assignment: []", user, src, src.name, registered? src.desc : src.assignment), 1)
+	src.add_fingerprint(user)
+	return
+

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -220,8 +220,8 @@
 				if(J.title == idcard.assignment)
 					job = J
 					break
-
-			access |= job.assistant_access
+			if(job &&!istype(idcard,/obj/item/weapon/card/id/syndicate))
+				access |= job.assistant_access
 			registered = TRUE
 			user << "<span class='notice'>You register the assistant as a part of your department.</span>"
 


### PR DESCRIPTION
Allows other jobs to register assistants to them, giving them related basic access on the spot. The intent is to make some use of shambling hordes of greyshirts. Accesses granted are up to change. Will have to add some notification for Sec Records/Crew Manifest to make tracking accesses easier. Pretty radical change so feel free to bash the idea.
