### PR TITLE
Storage Items can make different sounds, fixed default config error.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -20,7 +20,7 @@
 	max_combined_w_class = 21
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	playsound(src.loc, "rustle", 50, 1, -5)
+	playsound(get_turf(src), interaction_sound, 50, 1, -5)
 	..()
 
 /*
@@ -85,9 +85,17 @@
 
 /obj/item/weapon/storage/backpack/clown
 	name = "Giggles von Honkerton"
-	desc = "It's a backpack made by Honk! Co."
+	desc = "It's a honking backpack made by Honk! Co."
 	icon_state = "clownpack"
 	item_state = "clownpack"
+	interaction_sound = 'sound/items/bikehorn.ogg'
+
+/obj/item/weapon/storage/backpack/mime
+	name = "Parcel Parceaux"
+	desc = "A silent backpack made for those silent workers. Silence Co."
+	icon_state = "mimepack"
+	item_state = "mimepack"
+	interaction_sound = 'sound/misc/null.ogg'
 
 /obj/item/weapon/storage/backpack/medic
 	name = "medical backpack"
@@ -180,9 +188,3 @@
 	desc = "An exclusive satchel for Nanotrasen officers."
 	icon_state = "satchel-cap"
 	item_state = "captainpack"
-
-/obj/item/weapon/storage/backpack/mime
-	name = "Parcel Parceaux"
-	desc = "A silent backpack made for those silent workers. Silence Co."
-	icon_state = "mimepack"
-	item_state = "mimepack"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -21,7 +21,7 @@
 	var/mob/M = usr
 	if(!istype(over_object, /obj/screen))
 		return ..()
-	playsound(src.loc, "rustle", 50, 1, -5)
+	playsound(src.loc, interaction_sound, 50, 1, -5)
 	if (!M.restrained() && !M.stat && can_use())
 		switch(over_object.name)
 			if("r_hand")

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -7,6 +7,7 @@
 	w_class = 3.0
 	var/mob/affecting = null
 	var/deity_name = "Christ"
+	interaction_sound = "pageturn"//bibles sound like paper when opening/dropping/picking up
 
 /obj/item/weapon/storage/bible/booze
 	name = "bible"
@@ -117,5 +118,5 @@
 			A.reagents.add_reagent("cleaner",unholy2clean)		//it cleans their soul, get it? I'll get my coat...
 
 /obj/item/weapon/storage/bible/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	playsound(src.loc, "rustle", 50, 1, -5)
+	playsound(src.loc, interaction_sound, 50, 1, -5)
 	..()

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -162,7 +162,7 @@
 		if ((src.loc == user) && (src.locked == 1))
 			usr << "\red [src] is locked and cannot be opened!"
 		else if ((src.loc == user) && (!src.locked))
-			playsound(src.loc, "rustle", 50, 1, -5)
+			playsound(src.loc, interaction_sound, 50, 1, -5)
 			if (user.s_active)
 				user.s_active.close(user) //Close and re-open
 			src.show_to(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -9,6 +9,7 @@
 	name = "storage"
 	icon = 'icons/obj/storage.dmi'
 	w_class = 3.0
+	var/interaction_sound = "rustle"
 	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
 	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_hold isn't set)
 	var/max_w_class = 2 //Max size of objects that this object can store (in effect only if can_hold isn't set)
@@ -42,7 +43,7 @@
 
 		if(!(loc == usr) || (loc && loc.loc == usr))
 			return
-		playsound(loc, "rustle", 50, 1, -5)
+		playsound(loc, interaction_sound, 50, 1, -5)
 		if(!( M.restrained() ) && !( M.stat ))
 			switch(over_object.name)
 				if("r_hand")
@@ -335,7 +336,7 @@
 	return
 
 /obj/item/weapon/storage/attack_hand(mob/user)
-	playsound(loc, "rustle", 50, 1, -5)
+	playsound(loc, interaction_sound, 50, 1, -5)
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -35,6 +35,7 @@ Trial Admin		= +@ +SPAWN +REJUV +VAREDIT +BAN
 Badmin			= +@ +POSSESS +BUILDMODE +SERVER +FUN
 Game Admin		= +@ +STEALTH +SOUNDS +DEBUG
 Game Master		= +EVERYTHING
+Headmin			= +EVERYTHING
 
 Host			= +EVERYTHING
 


### PR DESCRIPTION
Fixed lack of headmin rank in default admin_ranks.txt, which spits out 3 duplicate runtime errors everytime you run the game with default config.

Storage items can now be given unique sounds! It will play the sound chosen when you pick up the item, open it up, put something in it, drop it, put it on, and take it off.

Clown backpacks honk.
Mime backpacks are deathly silent.
Bibles make paper rustling noise.

Also I moved the mime backpack under backpacks because SOMEONE had it under satchels.
big thanks to Danno for helping me make it work because I'm dumb.
