### PR TITLE
Borging removes all Antag Status, Borg Memory Config setting [Good to Go]

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -99,6 +99,7 @@
 	var/revival_brain_life = -1
 
 	var/rename_cyborg = 1
+	var/borg_remembers = 0
 
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
@@ -281,6 +282,8 @@
 					config.revival_brain_life		= text2num(value)
 				if("rename_cyborg")
 					config.rename_cyborg			= text2num(value)
+				if("borg_remembers")
+					config.borg_remembers			= text2num(value)
 				if("run_delay")
 					config.run_speed				= text2num(value)
 				if("walk_delay")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -86,11 +86,16 @@ datum/mind
 	proc/store_memory(new_text)
 		memory += "[new_text]<BR>"
 
-
-	proc/wipe_memory() //Wipes memories - RR
+	proc/wipe_memory()
 		memory = null
 
-	proc/remove_antag(specified_antag) //Removes an antag type's references - RR
+	proc/remove_antag(specified_antag)
+
+		/* - RR
+		Removes antag type's references from a mind.
+		objectives, uplinks, powers etc are all handled.
+		*/
+
 		special_role = null
 
 		if(objectives.len)
@@ -164,7 +169,7 @@ datum/mind
 				var/obj/item/device/radio/R = I
 				R.traitor_frequency = 0.0
 
-	proc/remove_all_antag() //Remove all Antag references - RR
+	proc/remove_all_antag() //For the Lazy amongst us.
 		remove_antag("Changeling")
 		remove_antag("Traitor")
 		remove_antag("NuclearOp")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -86,6 +86,93 @@ datum/mind
 	proc/store_memory(new_text)
 		memory += "[new_text]<BR>"
 
+
+	proc/wipe_memory() //Wipes memories - RR
+		memory = null
+
+	proc/remove_antag(specified_antag) //Removes an antag type's references - RR
+		special_role = null
+
+		if(objectives.len)
+			for(var/datum/objective/O in objectives)
+				objectives -= O
+				qdel(O)
+
+		switch(specified_antag)
+			if("Changeling")
+				if(src in ticker.mode.changelings)
+					ticker.mode.changelings -= src
+					current.remove_changeling_powers()
+					if(changeling)
+						qdel(changeling)
+						changeling = null
+
+			if("Traitor")
+				if(src in ticker.mode.traitors)
+					ticker.mode.traitors -= src
+					if(isAI(current))
+						var/mob/living/silicon/ai/A = current
+						A.set_zeroth_law("")
+						A.show_laws()
+
+			if("NuclearOp")
+				if(src in ticker.mode.syndicates)
+					ticker.mode.syndicates -= src
+					ticker.mode.update_synd_icons_removed(src)
+
+			if("Wizard")
+				if(src in ticker.mode.wizards)
+					ticker.mode.wizards -= src
+					current.spellremove(current)
+
+			if("Cultist")
+				if(src in ticker.mode.cult)
+					ticker.mode.cult -= src
+					ticker.mode.update_cult_icons_removed(src)
+					var/datum/game_mode/cult/cult = ticker.mode
+					if(istype(cult))
+						cult.memorize_cult_objectives(src)
+
+			if("Rev")
+				if(src in ticker.mode.revolutionaries)
+					ticker.mode.revolutionaries -= src
+					ticker.mode.update_rev_icons_removed(src)
+				if(src in ticker.mode.head_revolutionaries)
+					ticker.mode.head_revolutionaries -= src
+					ticker.mode.update_rev_icons_removed(src)
+
+			if("Malf")
+				if(src in ticker.mode.malf_ai)
+					ticker.mode.malf_ai -= src
+					var/mob/living/silicon/ai/A = current
+					A.verbs.Remove(/mob/living/silicon/ai/proc/choose_modules,
+						/datum/game_mode/malfunction/proc/takeover,
+						/datum/game_mode/malfunction/proc/ai_win)
+					A.malf_picker.remove_verbs(A)
+					A.make_laws()
+					qdel(A.malf_picker)
+					A.show_laws()
+					A.icon_state = "ai"
+
+		var/list/Mob_Contents = current.get_contents()
+		for(var/obj/item/I in Mob_Contents)
+			if(istype(I, /obj/item/device/pda))
+				var/obj/item/device/pda/P = I
+				P.lock_code = ""
+
+			else if(istype(I, /obj/item/device/radio))
+				var/obj/item/device/radio/R = I
+				R.traitor_frequency = 0.0
+
+	proc/remove_all_antag() //Remove all Antag references - RR
+		remove_antag("Changeling")
+		remove_antag("Traitor")
+		remove_antag("NuclearOp")
+		remove_antag("Wizard")
+		remove_antag("Cultist")
+		remove_antag("Rev")
+		remove_antag("Malf")
+
 	proc/show_memory(mob/recipient, window=1)
 		if(!recipient)
 			recipient = current
@@ -493,19 +580,10 @@ datum/mind
 		else if (href_list["revolution"])
 			switch(href_list["revolution"])
 				if("clear")
-					if(src in ticker.mode.revolutionaries)
-						ticker.mode.revolutionaries -= src
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a revolutionary!</B></FONT>"
-						ticker.mode.update_rev_icons_removed(src)
-						special_role = null
-					if(src in ticker.mode.head_revolutionaries)
-						ticker.mode.head_revolutionaries -= src
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a head revolutionary!</B></FONT>"
-						ticker.mode.update_rev_icons_removed(src)
-						special_role = null
+					remove_antag("Rev")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a revolutionary!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-rev'ed [current].")
 					log_admin("[key_name(usr)] has de-rev'ed [current].")
-
 				if("rev")
 					if(src in ticker.mode.head_revolutionaries)
 						ticker.mode.head_revolutionaries -= src
@@ -585,17 +663,10 @@ datum/mind
 		else if (href_list["cult"])
 			switch(href_list["cult"])
 				if("clear")
-					if(src in ticker.mode.cult)
-						ticker.mode.cult -= src
-						ticker.mode.update_cult_icons_removed(src)
-						special_role = null
-						var/datum/game_mode/cult/cult = ticker.mode
-						if (istype(cult))
-							cult.memorize_cult_objectives(src)
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a cultist!</B></FONT>"
-						memory = ""
-						message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
-						log_admin("[key_name(usr)] has de-cult'ed [current].")
+					remove_antag("Cultist")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a cultist!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
+					log_admin("[key_name(usr)] has de-cult'ed [current].")
 				if("cultist")
 					if(!(src in ticker.mode.cult))
 						ticker.mode.add_cultist(src)
@@ -626,12 +697,9 @@ datum/mind
 		else if (href_list["wizard"])
 			switch(href_list["wizard"])
 				if("clear")
-					if(src in ticker.mode.wizards)
-						ticker.mode.wizards -= src
-						special_role = null
-						current.spellremove(current)
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a wizard!</B></FONT>"
-						log_admin("[key_name(usr)] has de-wizard'ed [current].")
+					remove_antag("Wizard")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a wizard!</B></FONT>"
+					log_admin("[key_name(usr)] has de-wizard'ed [current].")
 				if("wizard")
 					if(!(src in ticker.mode.wizards))
 						ticker.mode.wizards += src
@@ -653,15 +721,10 @@ datum/mind
 		else if (href_list["changeling"])
 			switch(href_list["changeling"])
 				if("clear")
-					if(src in ticker.mode.changelings)
-						ticker.mode.changelings -= src
-						special_role = null
-						current.remove_changeling_powers()
-						if(changeling)
-							del(changeling)
-						current << "<FONT color='red' size = 3><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-changeling'ed [current].")
-						log_admin("[key_name(usr)] has de-changeling'ed [current].")
+					remove_antag("Changeling")
+					current << "<FONT color='red' size = 3><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-changeling'ed [current].")
+					log_admin("[key_name(usr)] has de-changeling'ed [current].")
 				if("changeling")
 					if(!(src in ticker.mode.changelings))
 						ticker.mode.changelings += src
@@ -687,15 +750,10 @@ datum/mind
 		else if (href_list["nuclear"])
 			switch(href_list["nuclear"])
 				if("clear")
-					if(src in ticker.mode.syndicates)
-						ticker.mode.syndicates -= src
-						ticker.mode.update_synd_icons_removed(src)
-						special_role = null
-						for (var/datum/objective/nuclear/O in objectives)
-							objectives-=O
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a syndicate operative!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-nuke op'ed [current].")
-						log_admin("[key_name(usr)] has de-nuke op'ed [current].")
+					remove_antag("NuclearOp")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a syndicate operative!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-nuke op'ed [current].")
+					log_admin("[key_name(usr)] has de-nuke op'ed [current].")
 				if("nuclear")
 					if(!(src in ticker.mode.syndicates))
 						ticker.mode.syndicates += src
@@ -741,17 +799,10 @@ datum/mind
 		else if (href_list["traitor"])
 			switch(href_list["traitor"])
 				if("clear")
-					if(src in ticker.mode.traitors)
-						ticker.mode.traitors -= src
-						special_role = null
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a traitor!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-traitor'ed [current].")
-						log_admin("[key_name(usr)] has de-traitor'ed [current].")
-						if(isAI(current))
-							var/mob/living/silicon/ai/A = current
-							A.set_zeroth_law("")
-							A.show_laws()
-
+					remove_antag("Traitor")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a traitor!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-traitor'ed [current].")
+					log_admin("[key_name(usr)] has de-traitor'ed [current].")
 
 				if("traitor")
 					if(!(src in ticker.mode.traitors))
@@ -820,26 +871,10 @@ datum/mind
 		else if (href_list["silicon"])
 			switch(href_list["silicon"])
 				if("unmalf")
-					if(src in ticker.mode.malf_ai)
-						ticker.mode.malf_ai -= src
-						special_role = null
-
-						var/mob/living/silicon/ai/A = current
-
-						A.verbs.Remove(/mob/living/silicon/ai/proc/choose_modules,
-							/datum/game_mode/malfunction/proc/takeover,
-							/datum/game_mode/malfunction/proc/ai_win)
-
-						A.malf_picker.remove_verbs(A)
-
-						A.make_laws()
-						qdel(A.malf_picker)
-						A.show_laws()
-						A.icon_state = "ai"
-
-						A << "\red <FONT size = 3><B>You have been patched! You are no longer malfunctioning!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-malf'ed [A].")
-						log_admin("[key_name(usr)] has de-malf'ed [A].")
+					remove_antag("Malf")
+					current << "\red <FONT size = 3><B>You have been patched! You are no longer malfunctioning!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-malf'ed [current].")
+					log_admin("[key_name(usr)] has de-malf'ed [current].")
 
 				if("malf")
 					make_AI_Malf()
@@ -894,37 +929,6 @@ datum/mind
 				obj_count++
 
 		edit_memory()
-/*
-	proc/clear_memory(var/silent = 1)
-		var/datum/game_mode/current_mode = ticker.mode
-
-		// remove traitor uplinks
-		var/list/L = current.get_contents()
-		for (var/t in L)
-			if (istype(t, /obj/item/device/pda))
-				if (t:uplink) qdel(t:uplink)
-				t:uplink = null
-			else if (istype(t, /obj/item/device/radio))
-				if (t:traitorradio) qdel(t:traitorradio)
-				t:traitorradio = null
-				t:traitor_frequency = 0.0
-			else if (istype(t, /obj/item/weapon/SWF_uplink) || istype(t, /obj/item/weapon/syndicate_uplink))
-				if (t:origradio)
-					var/obj/item/device/radio/R = t:origradio
-					R.loc = current.loc
-					R.traitorradio = null
-					R.traitor_frequency = 0.0
-				qdel(t)
-
-		// remove wizards spells
-		//If there are more special powers that need removal, they can be procced into here./N
-		current.spellremove(current)
-
-		// clear memory
-		memory = ""
-		special_role = null
-
-*/
 
 	proc/find_syndicate_uplink()
 		var/list/L = current.get_contents()

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -226,7 +226,9 @@
 			M.brainmob.mind.transfer_to(O)
 
 			if(O.mind && O.mind.special_role)
-				O.mind.store_memory("As a cyborg, any objectives listed here are null and void, and will be marked as failed. They are simply here for memory purposes.")
+				O.mind.wipe_memory()
+				O.mind.remove_all_antag()
+				O << "<span class='warning'>Your Memories have been wiped!</span>"
 
 			O.job = "Cyborg"
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -226,9 +226,12 @@
 			M.brainmob.mind.transfer_to(O)
 
 			if(O.mind && O.mind.special_role)
-				O.mind.wipe_memory()
 				O.mind.remove_all_antag()
-				O << "<span class='warning'>You forget everything about your past life!</span>"
+				if(!config.borg_remembers)
+					O.mind.store_memory("All Objectives listed here are considered Failed.")
+				else
+					O << "<span class='warning'>You forget everything about your past life!</span>"
+					O.mind.wipe_memory()
 
 			O.job = "Cyborg"
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -228,7 +228,7 @@
 			if(O.mind && O.mind.special_role)
 				O.mind.wipe_memory()
 				O.mind.remove_all_antag()
-				O << "<span class='warning'>Your Memories have been wiped!</span>"
+				O << "<span class='warning'>You forget everything about your past life!</span>"
 
 			O.job = "Cyborg"
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -23,6 +23,11 @@ REVIVAL_BRAIN_LIFE -1
 # Whether cyborgs can rename themselves at roundstart or when built.  Has no effect on roboticists renaming cyborgs the normal way.  Set to 0 to disable self-renaming.
 RENAME_CYBORG 1
 
+### MEMORY ###
+
+# Whether cyborgs remember their past lives, 1 = Remember, 0 = Don't remember
+BORG_REMEMBERS 0
+
 ### MOB MOVEMENT ###
 
 ## We suggest editing these variables ingame to find a good speed for your server.


### PR DESCRIPTION
Idea shamelessly nicked from Pete's TODO list (I figure I'd take something off your load)

Adds remove_antag(specified_antag) which removes all references to an antag type inside a mind
Update mind.dm's href "clear" references to use remove_antag()
remove_antag() is designed to be run on a mind
adds remove_all_antag() which calls remove_antag() on all antag types possible
wipe_memory() is just a quick shortcut for memory = null

These are MIND PROCS, Don't run them on mobs, run them on the mob's mind.

Config setting so Borg's no longer retain memories after borging, This was intended functionality, But rather than do it somebody put a message telling borg's to ignore their memories, God I love the Ancient coders.
