### PR TITLE
After 3 god damn years the Clown Planet returns. Nerfs the fuck out of the HONKBlaster since you'll be able to build multiple.

### DIFF
--- a/NTstation13.dme
+++ b/NTstation13.dme
@@ -14,6 +14,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\metastation.dm"
+#include "_maps\RandomZLevels\clownplanet.dmm"
 #include "code\_compile_options.dm"
 #include "code\hub.dm"
 #include "code\world.dm"

--- a/_maps/RandomZLevels/clownplanet.dmm
+++ b/_maps/RandomZLevels/clownplanet.dmm
@@ -1,97 +1,123 @@
 "aa" = (/turf/unsimulated/wall,/area/planet/clown)
 "ab" = (/turf/simulated/mineral/random/clown,/area/planet/clown)
-"ac" = (/turf/simulated/floor/grass,/area/planet/clown)
-"ad" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"ae" = (/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"af" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"ag" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"ah" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"ai" = (/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aj" = (/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"ak" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"al" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"am" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"an" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"ao" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"ap" = (/obj/machinery/gateway{dir = 9},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aq" = (/obj/machinery/gateway{dir = 1},/turf/simulated/floor/grass,/area/planet/clown)
-"ar" = (/obj/machinery/gateway{dir = 5},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"as" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"at" = (/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"au" = (/obj/machinery/gateway{dir = 8},/turf/simulated/floor/grass,/area/planet/clown)
-"av" = (/obj/machinery/gateway/centeraway,/turf/simulated/floor/grass,/area/planet/clown)
-"aw" = (/obj/machinery/gateway{dir = 4},/turf/simulated/floor/grass,/area/planet/clown)
-"ax" = (/obj/structure/table/woodentable,/obj/item/clothing/mask/gas/clown_hat,/obj/item/clothing/gloves/rainbow/clown,/obj/item/clothing/shoes/clown_shoes{desc = "These shoes appear var-edited!."; name = "uhangi's shoes"; slowdown = -1},/obj/item/clothing/under/rank/clown,/obj/item/device/pda/clown,/obj/item/weapon/storage/backpack/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"ay" = (/obj/structure/table/woodentable,/obj/item/seeds/cashseed,/obj/item/seeds/cashseed,/turf/simulated/floor/grass,/area/planet/clown)
-"az" = (/obj/machinery/gateway{dir = 10},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aA" = (/obj/machinery/gateway,/turf/simulated/floor/grass,/area/planet/clown)
-"aB" = (/obj/machinery/gateway{dir = 6},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aC" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aD" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aE" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aF" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/signpost{desc = "The sign says: Please don't mine the Bananium!"; name = "Welcome to Clown Planet"},/turf/simulated/floor/grass,/area/planet/clown)
-"aG" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"aH" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"aI" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aJ" = (/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aK" = (/obj/machinery/hydroponics/soil,/turf/simulated/floor/grass,/area/planet/clown)
-"aL" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aM" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aN" = (/obj/structure/flora/ausbushes/palebush,/turf/simulated/floor/grass,/area/planet/clown)
-"aO" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
-"aP" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
-"aQ" = (/turf/simulated/wall/mineral/clown,/area/planet/clown)
-"aR" = (/obj/structure/mineral_door/gold,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aS" = (/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aT" = (/obj/structure/stool/bed/chair/comfy/lime,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aU" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/rainbow/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aV" = (/obj/structure/stool/bed/chair/office/light{dir = 8},/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aW" = (/obj/structure/filingcabinet,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aX" = (/obj/machinery/door/window/westleft,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aY" = (/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
-"aZ" = (/obj/machinery/gun_turret,/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
-"ba" = (/turf/simulated/floor,/area/planet/clown)
-"bb" = (/obj/structure/closet/crate,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor,/area/planet/clown)
+"ac" = (/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"ad" = (/turf/simulated/wall/mineral/clown,/area/planet/clown)
+"ae" = (/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
+"af" = (/turf/simulated/floor/grass,/area/planet/clown)
+"ag" = (/obj/item/weapon/pickaxe/diamonddrill,/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
+"ah" = (/obj/structure/ore_box,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ai" = (/obj/item/seeds/bananaseed,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aj" = (/obj/item/weapon/pickaxe,/turf/simulated/floor/plating,/area/planet/clown)
+"ak" = (/turf/simulated/floor/plating,/area/planet/clown)
+"al" = (/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/planet/clown)
+"am" = (/obj/effect/decal/remains/human,/obj/item/clothing/head/helmet/space/rig/ancient,/obj/item/clothing/suit/space/rig/ancient,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
+"an" = (/obj/item/weapon/paper/crumpled/bloody{info = "I was told getting the bananium would be easy...fuck...they lied...send word to my family in the Alpha Minorious Sector if you find this."},/turf/simulated/floor/grass,/area/planet/clown)
+"ao" = (/obj/item/seeds/bananaseed,/mob/living/simple_animal/hostile/asteroid/goldgrub,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ap" = (/obj/item/seeds/bananaseed,/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aq" = (/obj/item/seeds/bananaseed,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ar" = (/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"as" = (/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"at" = (/obj/structure/barricade/wooden,/turf/simulated/floor/grass,/area/planet/clown)
+"au" = (/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"av" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aw" = (/mob/living/simple_animal/hostile/asteroid/goliath,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ax" = (/obj/machinery/door/airlock/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"ay" = (/obj/machinery/mineral/input,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"az" = (/obj/machinery/mineral/mint,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aA" = (/obj/machinery/mineral/output,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aB" = (/obj/effect/decal/remains/human,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aC" = (/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aD" = (/obj/structure/ore_box,/turf/simulated/floor/grass,/area/planet/clown)
+"aE" = (/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/weapon/pickaxe,/turf/simulated/floor/grass,/area/planet/clown)
+"aF" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aG" = (/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aH" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aI" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aJ" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aK" = (/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aL" = (/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aM" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aN" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aO" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aP" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aQ" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aR" = (/obj/machinery/gateway{dir = 9},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aS" = (/obj/machinery/gateway{dir = 1},/turf/simulated/floor/grass,/area/planet/clown)
+"aT" = (/obj/machinery/gateway{dir = 5},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aU" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aV" = (/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aW" = (/obj/machinery/gateway{dir = 8},/turf/simulated/floor/grass,/area/planet/clown)
+"aX" = (/obj/machinery/gateway/centeraway,/turf/simulated/floor/grass,/area/planet/clown)
+"aY" = (/obj/machinery/gateway{dir = 4},/turf/simulated/floor/grass,/area/planet/clown)
+"aZ" = (/obj/structure/table/woodentable,/obj/item/clothing/mask/gas/clown_hat,/obj/item/clothing/gloves/rainbow/clown,/obj/item/clothing/shoes/clown_shoes{desc = "These shoes appear var-edited!."; name = "uhangi's shoes"; slowdown = -1},/obj/item/clothing/under/rank/clown,/obj/item/device/pda/clown,/obj/item/weapon/storage/backpack/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"ba" = (/obj/structure/table/woodentable,/obj/item/seeds/cashseed,/obj/item/seeds/cashseed,/turf/simulated/floor/grass,/area/planet/clown)
+"bb" = (/obj/machinery/gateway{dir = 10},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"bc" = (/obj/machinery/gateway,/turf/simulated/floor/grass,/area/planet/clown)
+"bd" = (/obj/machinery/gateway{dir = 6},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"be" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bf" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bg" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bh" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/signpost{desc = "The sign says: Please don't mine the Bananium!"; name = "Welcome to Clown Planet"},/turf/simulated/floor/grass,/area/planet/clown)
+"bi" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"bj" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"bk" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"bl" = (/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bm" = (/obj/machinery/hydroponics/soil,/turf/simulated/floor/grass,/area/planet/clown)
+"bn" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"bo" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bp" = (/obj/structure/flora/ausbushes/palebush,/turf/simulated/floor/grass,/area/planet/clown)
+"bq" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
+"br" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
+"bs" = (/obj/structure/mineral_door/gold,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bt" = (/obj/structure/stool/bed/chair/comfy/lime,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bu" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/rainbow/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bv" = (/obj/structure/stool/bed/chair/office/light{dir = 8},/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bw" = (/obj/structure/filingcabinet,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bx" = (/obj/machinery/door/window/westleft,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"by" = (/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
+"bz" = (/obj/machinery/gun_turret,/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
+"bA" = (/turf/simulated/floor,/area/planet/clown)
+"bB" = (/obj/structure/closet/crate,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor,/area/planet/clown)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaababababababababababababababababababababababababababababababababababababababaa
 aaababababababababababababababababababababababababababababababababababababababaa
+aaabababababababababababababacabababababababababababadababababababadabababababaa
+aaababababababababababaeafafafagababababababababababafafababahahaiajakalabababaa
+aaababababababababababababafamanafabababababababababafafadaiaoapaqarakakabababaa
+aaababababababababababafafaeafabasabababababababababafafatauavauauawauakabababaa
+aaababababababababababababacabababababababababababababafaxauayazaAauauaBabababaa
+aaabababababababababababacacabababababababababababababafadatatadadatadadadababaa
+aaabababababababababababababababababababababababababafafafafafababaCaCaCaCababaa
+aaababababababababababababababababababababababababababafafafafabababaDaDaEababaa
+aaabababababababababababababababababababababababababababafafafabababababaDababaa
 aaababababababababababababababababababababababababababababababababababababababaa
 aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaabababababacacabababababacacababababababababababababababababababababababababaa
-aaabababababacacacacadadadacacacabababacacababababababababababababababababababaa
-aaabababababacaeafafagagagafafafafahaiajacacabababababababababababababababababaa
-aaababababacacafafafagagagafafafafahajajacacabababacabababababababababababababaa
-aaababababababafafafagakagafalalalamananacacacacacacacababababababababababababaa
-aaabababababajaoaoaoagagapaqarasasasatatacacacacacabacababababababababababababaa
-aaababababacajaoaoaoaoaoauavawaxayayayayajacacacacababababababababababababababaa
-aaabababababadagagakaoaoazaAaBaCaCaCaCaDajacacacacacabababababababababababababaa
-aaababababacadadadadajajaEafamamamamamanajacacacacacabababababababababababababaa
-aaababababacadadadadajajaoafamaFamaGaGaHanadacacacababababababababababababababaa
-aaabababababadadadagaoaoaIafamamamaGaGaHanadacaJaKababababababababababababababaa
-aaabababababababacafaoaoaLadanananaDanananadacacaKababababababababababababababaa
-aaababababababacacafaoaoaMadadadadadadadadadaNaNaNababababababababababababababaa
-aaababababaKacacacaOaOaOaPadadadaPaPaPaPadadabababababababababababababababababaa
-aaababababaKabacaKaQaQaQaQaQaRaQaQaQaQaQacababababababababababababababababababaa
-aaabababababababaKaQaSaSaTaTaSaSaUaVaWaQabababababababababababababababababababaa
-aaababababababababaQaQaSaSaSaSaSaXaSaWaQabababababababababababababababababababaa
-aaabababababababababaQaQaQaRaQaQaQaQaQaQabababababababababababababababababababaa
-aaabababababababababababaQaYaYaYaZaQabababababababababababababababababababababaa
-aaabababababababababababaQbabababbaQabababababababababababababababababababababaa
-aaabababababababababababaQbabababbaQabababababababababababababababababababababaa
-aaabababababababababababaQbabababaaQabababababababababababababababababababababaa
-aaabababababababababababaQbbbbbbbbaQabababababababababababababababababababababaa
-aaabababababababababababaQaQaQaQaQaQabababababababababababababababababababababaa
+aaabababababafafabababababafafababababababababababababababababababababababababaa
+aaabababababafafafafaFaFaFafafafabababafafababababababababababababababababababaa
+aaabababababafaGaHaHaIaIaIaHaHaHaHaJaKaLafafabababababababababababababababababaa
+aaababababafafaHaHaHaIaIaIaHaHaHaHaJaLaLafafabababafabababababababababababababaa
+aaababababababaHaHaHaIaMaIaHaNaNaNaOaPaPafafafafafafafababababababababababababaa
+aaabababababaLaQaQaQaIaIaRaSaTaUaUaUaVaVafafafafafabafababababababababababababaa
+aaababababafaLaQaQaQaQaQaWaXaYaZbabababaaLafafafafababababababababababababababaa
+aaabababababaFaIaIaMaQaQbbbcbdbebebebebfaLafafafafafabababababababababababababaa
+aaababababafaFaFaFaFaLaLbgaHaOaOaOaOaOaPaLafafafafafabababababababababababababaa
+aaababababafaFaFaFaFaLaLaQaHaObhaObibibjaPaFafafafababababababababababababababaa
+aaabababababaFaFaFaIaQaQbkaHaOaOaObibibjaPaFafblbmababababababababababababababaa
+aaabababababababafaHaQaQbnaFaPaPaPbfaPaPaPaFafafbmababababababababababababababaa
+aaababababababafafaHaQaQboaFaFaFaFaFaFaFaFaFbpbpbpababababababababababababababaa
+aaababababbmafafafbqbqbqbraFaFaFbrbrbrbraFaFabababababababababababababababababaa
+aaababababbmabafbmadadadadadbsadadadadadafababababababababababababababababababaa
+aaabababababababbmadauaubtbtauaububvbwadabababababababababababababababababababaa
+aaababababababababadadauauauauaubxaubwadabababababababababababababababababababaa
+aaabababababababababadadadbsadadadadadadabababababababababababababababababababaa
+aaabababababababababababadbybybybzadabababababababababababababababababababababaa
+aaabababababababababababadbAbAbAbBadabababababababababababababababababababababaa
+aaabababababababababababadbAbAbAbBadabababababababababababababababababababababaa
+aaabababababababababababadbAbAbAbAadabababababababababababababababababababababaa
+aaabababababababababababadbBbBbBbBadabababababababababababababababababababababaa
+aaabababababababababababadadadadadadabababababababababababababababababababababaa
 aaababababababababababababababababababababababababababababababababababababababaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}

--- a/_maps/RandomZLevels/clownplanet.dmm
+++ b/_maps/RandomZLevels/clownplanet.dmm
@@ -1,0 +1,97 @@
+"aa" = (/turf/unsimulated/wall,/area/planet/clown)
+"ab" = (/turf/simulated/mineral/random/clown,/area/planet/clown)
+"ac" = (/turf/simulated/floor/grass,/area/planet/clown)
+"ad" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"ae" = (/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"af" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"ag" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"ah" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"ai" = (/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aj" = (/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"ak" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"al" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"am" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"an" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"ao" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"ap" = (/obj/machinery/gateway{dir = 9},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aq" = (/obj/machinery/gateway{dir = 1},/turf/simulated/floor/grass,/area/planet/clown)
+"ar" = (/obj/machinery/gateway{dir = 5},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"as" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"at" = (/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"au" = (/obj/machinery/gateway{dir = 8},/turf/simulated/floor/grass,/area/planet/clown)
+"av" = (/obj/machinery/gateway/centeraway,/turf/simulated/floor/grass,/area/planet/clown)
+"aw" = (/obj/machinery/gateway{dir = 4},/turf/simulated/floor/grass,/area/planet/clown)
+"ax" = (/obj/structure/table/woodentable,/obj/item/clothing/mask/gas/clown_hat,/obj/item/clothing/gloves/rainbow/clown,/obj/item/clothing/shoes/clown_shoes{desc = "These shoes appear var-edited!."; name = "uhangi's shoes"; slowdown = -1},/obj/item/clothing/under/rank/clown,/obj/item/device/pda/clown,/obj/item/weapon/storage/backpack/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"ay" = (/obj/structure/table/woodentable,/obj/item/seeds/cashseed,/obj/item/seeds/cashseed,/turf/simulated/floor/grass,/area/planet/clown)
+"az" = (/obj/machinery/gateway{dir = 10},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aA" = (/obj/machinery/gateway,/turf/simulated/floor/grass,/area/planet/clown)
+"aB" = (/obj/machinery/gateway{dir = 6},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aC" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aD" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aE" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aF" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/signpost{desc = "The sign says: Please don't mine the Bananium!"; name = "Welcome to Clown Planet"},/turf/simulated/floor/grass,/area/planet/clown)
+"aG" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aH" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aI" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aJ" = (/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aK" = (/obj/machinery/hydroponics/soil,/turf/simulated/floor/grass,/area/planet/clown)
+"aL" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aM" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aN" = (/obj/structure/flora/ausbushes/palebush,/turf/simulated/floor/grass,/area/planet/clown)
+"aO" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
+"aP" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
+"aQ" = (/turf/simulated/wall/mineral/clown,/area/planet/clown)
+"aR" = (/obj/structure/mineral_door/gold,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aS" = (/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aT" = (/obj/structure/stool/bed/chair/comfy/lime,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aU" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/rainbow/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aV" = (/obj/structure/stool/bed/chair/office/light{dir = 8},/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aW" = (/obj/structure/filingcabinet,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aX" = (/obj/machinery/door/window/westleft,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aY" = (/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
+"aZ" = (/obj/machinery/gun_turret,/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
+"ba" = (/turf/simulated/floor,/area/planet/clown)
+"bb" = (/obj/structure/closet/crate,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor,/area/planet/clown)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaabababababacacabababababacacababababababababababababababababababababababababaa
+aaabababababacacacacadadadacacacabababacacababababababababababababababababababaa
+aaabababababacaeafafagagagafafafafahaiajacacabababababababababababababababababaa
+aaababababacacafafafagagagafafafafahajajacacabababacabababababababababababababaa
+aaababababababafafafagakagafalalalamananacacacacacacacababababababababababababaa
+aaabababababajaoaoaoagagapaqarasasasatatacacacacacabacababababababababababababaa
+aaababababacajaoaoaoaoaoauavawaxayayayayajacacacacababababababababababababababaa
+aaabababababadagagakaoaoazaAaBaCaCaCaCaDajacacacacacabababababababababababababaa
+aaababababacadadadadajajaEafamamamamamanajacacacacacabababababababababababababaa
+aaababababacadadadadajajaoafamaFamaGaGaHanadacacacababababababababababababababaa
+aaabababababadadadagaoaoaIafamamamaGaGaHanadacaJaKababababababababababababababaa
+aaabababababababacafaoaoaLadanananaDanananadacacaKababababababababababababababaa
+aaababababababacacafaoaoaMadadadadadadadadadaNaNaNababababababababababababababaa
+aaababababaKacacacaOaOaOaPadadadaPaPaPaPadadabababababababababababababababababaa
+aaababababaKabacaKaQaQaQaQaQaRaQaQaQaQaQacababababababababababababababababababaa
+aaabababababababaKaQaSaSaTaTaSaSaUaVaWaQabababababababababababababababababababaa
+aaababababababababaQaQaSaSaSaSaSaXaSaWaQabababababababababababababababababababaa
+aaabababababababababaQaQaQaRaQaQaQaQaQaQabababababababababababababababababababaa
+aaabababababababababababaQaYaYaYaZaQabababababababababababababababababababababaa
+aaabababababababababababaQbabababbaQabababababababababababababababababababababaa
+aaabababababababababababaQbabababbaQabababababababababababababababababababababaa
+aaabababababababababababaQbabababaaQabababababababababababababababababababababaa
+aaabababababababababababaQbbbbbbbbaQabababababababababababababababababababababaa
+aaabababababababababababaQaQaQaQaQaQabababababababababababababababababababababaa
+aaababababababababababababababababababababababababababababababababababababababaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}

--- a/_maps/RandomZLevels/clownplanet.dmm
+++ b/_maps/RandomZLevels/clownplanet.dmm
@@ -1,123 +1,122 @@
-"aa" = (/turf/unsimulated/wall,/area/planet/clown)
-"ab" = (/turf/simulated/mineral/random/clown,/area/planet/clown)
-"ac" = (/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"ad" = (/turf/simulated/wall/mineral/clown,/area/planet/clown)
-"ae" = (/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
-"af" = (/turf/simulated/floor/grass,/area/planet/clown)
-"ag" = (/obj/item/weapon/pickaxe/diamonddrill,/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
-"ah" = (/obj/structure/ore_box,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"ai" = (/obj/item/seeds/bananaseed,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aj" = (/obj/item/weapon/pickaxe,/turf/simulated/floor/plating,/area/planet/clown)
-"ak" = (/turf/simulated/floor/plating,/area/planet/clown)
-"al" = (/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/planet/clown)
-"am" = (/obj/effect/decal/remains/human,/obj/item/clothing/head/helmet/space/rig/ancient,/obj/item/clothing/suit/space/rig/ancient,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
-"an" = (/obj/item/weapon/paper/crumpled/bloody{info = "I was told getting the bananium would be easy...fuck...they lied...send word to my family in the Alpha Minorious Sector if you find this."},/turf/simulated/floor/grass,/area/planet/clown)
-"ao" = (/obj/item/seeds/bananaseed,/mob/living/simple_animal/hostile/asteroid/goldgrub,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"ap" = (/obj/item/seeds/bananaseed,/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aq" = (/obj/item/seeds/bananaseed,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"ar" = (/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"as" = (/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"at" = (/obj/structure/barricade/wooden,/turf/simulated/floor/grass,/area/planet/clown)
-"au" = (/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"av" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aw" = (/mob/living/simple_animal/hostile/asteroid/goliath,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"ax" = (/obj/machinery/door/airlock/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"ay" = (/obj/machinery/mineral/input,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"az" = (/obj/machinery/mineral/mint,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aA" = (/obj/machinery/mineral/output,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aB" = (/obj/effect/decal/remains/human,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"aC" = (/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aD" = (/obj/structure/ore_box,/turf/simulated/floor/grass,/area/planet/clown)
-"aE" = (/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/weapon/pickaxe,/turf/simulated/floor/grass,/area/planet/clown)
-"aF" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aG" = (/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aH" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aI" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aJ" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"aK" = (/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aL" = (/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"aM" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aN" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aO" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"aP" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"aQ" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aR" = (/obj/machinery/gateway{dir = 9},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aS" = (/obj/machinery/gateway{dir = 1},/turf/simulated/floor/grass,/area/planet/clown)
-"aT" = (/obj/machinery/gateway{dir = 5},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"aU" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aV" = (/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"aW" = (/obj/machinery/gateway{dir = 8},/turf/simulated/floor/grass,/area/planet/clown)
-"aX" = (/obj/machinery/gateway/centeraway,/turf/simulated/floor/grass,/area/planet/clown)
-"aY" = (/obj/machinery/gateway{dir = 4},/turf/simulated/floor/grass,/area/planet/clown)
-"aZ" = (/obj/structure/table/woodentable,/obj/item/clothing/mask/gas/clown_hat,/obj/item/clothing/gloves/rainbow/clown,/obj/item/clothing/shoes/clown_shoes{desc = "These shoes appear var-edited!."; name = "uhangi's shoes"; slowdown = -1},/obj/item/clothing/under/rank/clown,/obj/item/device/pda/clown,/obj/item/weapon/storage/backpack/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"ba" = (/obj/structure/table/woodentable,/obj/item/seeds/cashseed,/obj/item/seeds/cashseed,/turf/simulated/floor/grass,/area/planet/clown)
-"bb" = (/obj/machinery/gateway{dir = 10},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"bc" = (/obj/machinery/gateway,/turf/simulated/floor/grass,/area/planet/clown)
-"bd" = (/obj/machinery/gateway{dir = 6},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"be" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"bf" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"bg" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"bh" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/signpost{desc = "The sign says: Please don't mine the Bananium!"; name = "Welcome to Clown Planet"},/turf/simulated/floor/grass,/area/planet/clown)
-"bi" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"bj" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
-"bk" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"bl" = (/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"bm" = (/obj/machinery/hydroponics/soil,/turf/simulated/floor/grass,/area/planet/clown)
-"bn" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
-"bo" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
-"bp" = (/obj/structure/flora/ausbushes/palebush,/turf/simulated/floor/grass,/area/planet/clown)
-"bq" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
-"br" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
-"bs" = (/obj/structure/mineral_door/gold,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"bt" = (/obj/structure/stool/bed/chair/comfy/lime,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"bu" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/rainbow/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"bv" = (/obj/structure/stool/bed/chair/office/light{dir = 8},/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"bw" = (/obj/structure/filingcabinet,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"bx" = (/obj/machinery/door/window/westleft,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
-"by" = (/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
-"bz" = (/obj/machinery/gun_turret,/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
-"bA" = (/turf/simulated/floor,/area/planet/clown)
-"bB" = (/obj/structure/closet/crate,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor,/area/planet/clown)
+"aa" = (/turf/simulated/mineral/random/clown,/area/planet/clown)
+"ab" = (/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"ac" = (/turf/simulated/wall/mineral/clown,/area/planet/clown)
+"ad" = (/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
+"ae" = (/turf/simulated/floor/grass,/area/planet/clown)
+"af" = (/obj/item/weapon/pickaxe/diamonddrill,/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
+"ag" = (/obj/structure/ore_box,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ah" = (/obj/item/seeds/bananaseed,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ai" = (/obj/item/weapon/pickaxe,/turf/simulated/floor/plating,/area/planet/clown)
+"aj" = (/turf/simulated/floor/plating,/area/planet/clown)
+"ak" = (/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/planet/clown)
+"al" = (/obj/effect/decal/remains/human,/obj/item/clothing/head/helmet/space/rig/ancient,/obj/item/clothing/suit/space/rig/ancient,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/grass,/area/planet/clown)
+"am" = (/obj/item/weapon/paper/crumpled/bloody{info = "I was told getting the bananium would be easy...fuck...they lied...send word to my family in the Alpha Minorious Sector if you find this."},/turf/simulated/floor/grass,/area/planet/clown)
+"an" = (/obj/item/seeds/bananaseed,/mob/living/simple_animal/hostile/asteroid/goldgrub,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ao" = (/obj/item/seeds/bananaseed,/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ap" = (/obj/item/seeds/bananaseed,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aq" = (/obj/effect/landmark/corpse/clown,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ar" = (/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/obj/item/weapon/ore/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"as" = (/obj/structure/barricade/wooden,/turf/simulated/floor/grass,/area/planet/clown)
+"at" = (/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"au" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"av" = (/mob/living/simple_animal/hostile/asteroid/goliath,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aw" = (/obj/machinery/door/airlock/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"ax" = (/obj/machinery/mineral/input,/obj/effect/decal/cleanable/blood,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"ay" = (/obj/machinery/mineral/mint,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"az" = (/obj/machinery/mineral/output,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aA" = (/obj/effect/decal/remains/human,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"aB" = (/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aC" = (/obj/structure/ore_box,/turf/simulated/floor/grass,/area/planet/clown)
+"aD" = (/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/weapon/pickaxe,/turf/simulated/floor/grass,/area/planet/clown)
+"aE" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aF" = (/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aG" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aH" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aI" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aJ" = (/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aK" = (/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aL" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aM" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aN" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aO" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"aP" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aQ" = (/obj/machinery/gateway{dir = 9},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aR" = (/obj/machinery/gateway{dir = 1},/turf/simulated/floor/grass,/area/planet/clown)
+"aS" = (/obj/machinery/gateway{dir = 5},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"aT" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aU" = (/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aV" = (/obj/machinery/gateway{dir = 8},/turf/simulated/floor/grass,/area/planet/clown)
+"aW" = (/obj/machinery/gateway/centeraway,/turf/simulated/floor/grass,/area/planet/clown)
+"aX" = (/obj/machinery/gateway{dir = 4},/turf/simulated/floor/grass,/area/planet/clown)
+"aY" = (/obj/structure/table/woodentable,/obj/item/clothing/mask/gas/clown_hat,/obj/item/clothing/gloves/rainbow/clown,/obj/item/clothing/shoes/clown_shoes{desc = "These shoes appear var-edited!."; name = "uhangi's shoes"; slowdown = -1},/obj/item/clothing/under/rank/clown,/obj/item/device/pda/clown,/obj/item/weapon/storage/backpack/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"aZ" = (/obj/structure/table/woodentable,/obj/item/seeds/cashseed,/obj/item/seeds/cashseed,/turf/simulated/floor/grass,/area/planet/clown)
+"ba" = (/obj/machinery/gateway{dir = 10},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"bb" = (/obj/machinery/gateway,/turf/simulated/floor/grass,/area/planet/clown)
+"bc" = (/obj/machinery/gateway{dir = 6},/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"bd" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"be" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bf" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bg" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/signpost{desc = "The sign says: Please don't mine the Bananium!"; name = "Welcome to Clown Planet"},/turf/simulated/floor/grass,/area/planet/clown)
+"bh" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"bi" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/grass,/area/planet/clown)
+"bj" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"bk" = (/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bl" = (/obj/machinery/hydroponics/soil,/turf/simulated/floor/grass,/area/planet/clown)
+"bm" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/planet/clown)
+"bn" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor/grass,/area/planet/clown)
+"bo" = (/obj/structure/flora/ausbushes/palebush,/turf/simulated/floor/grass,/area/planet/clown)
+"bp" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
+"bq" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/planet/clown)
+"br" = (/obj/structure/mineral_door/gold,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bs" = (/obj/structure/stool/bed/chair/comfy/lime,/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bt" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/rainbow/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bu" = (/obj/structure/stool/bed/chair/office/light{dir = 8},/mob/living/simple_animal/hostile/retaliate/clown,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bv" = (/obj/structure/filingcabinet,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bw" = (/obj/machinery/door/window/westleft,/turf/simulated/floor{dir = 8; icon_state = "barber"},/area/planet/clown)
+"bx" = (/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
+"by" = (/obj/machinery/gun_turret,/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/planet/clown)
+"bz" = (/turf/simulated/floor,/area/planet/clown)
+"bA" = (/obj/structure/closet/crate,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/obj/item/stack/sheet/mineral/clown,/turf/simulated/floor,/area/planet/clown)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaabababababababababababababacabababababababababababadababababababadabababababaa
-aaababababababababababaeafafafagababababababababababafafababahahaiajakalabababaa
-aaababababababababababababafamanafabababababababababafafadaiaoapaqarakakabababaa
-aaababababababababababafafaeafabasabababababababababafafatauavauauawauakabababaa
-aaababababababababababababacabababababababababababababafaxauayazaAauauaBabababaa
-aaabababababababababababacacabababababababababababababafadatatadadatadadadababaa
-aaabababababababababababababababababababababababababafafafafafababaCaCaCaCababaa
-aaababababababababababababababababababababababababababafafafafabababaDaDaEababaa
-aaabababababababababababababababababababababababababababafafafabababababaDababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaabababababafafabababababafafababababababababababababababababababababababababaa
-aaabababababafafafafaFaFaFafafafabababafafababababababababababababababababababaa
-aaabababababafaGaHaHaIaIaIaHaHaHaHaJaKaLafafabababababababababababababababababaa
-aaababababafafaHaHaHaIaIaIaHaHaHaHaJaLaLafafabababafabababababababababababababaa
-aaababababababaHaHaHaIaMaIaHaNaNaNaOaPaPafafafafafafafababababababababababababaa
-aaabababababaLaQaQaQaIaIaRaSaTaUaUaUaVaVafafafafafabafababababababababababababaa
-aaababababafaLaQaQaQaQaQaWaXaYaZbabababaaLafafafafababababababababababababababaa
-aaabababababaFaIaIaMaQaQbbbcbdbebebebebfaLafafafafafabababababababababababababaa
-aaababababafaFaFaFaFaLaLbgaHaOaOaOaOaOaPaLafafafafafabababababababababababababaa
-aaababababafaFaFaFaFaLaLaQaHaObhaObibibjaPaFafafafababababababababababababababaa
-aaabababababaFaFaFaIaQaQbkaHaOaOaObibibjaPaFafblbmababababababababababababababaa
-aaabababababababafaHaQaQbnaFaPaPaPbfaPaPaPaFafafbmababababababababababababababaa
-aaababababababafafaHaQaQboaFaFaFaFaFaFaFaFaFbpbpbpababababababababababababababaa
-aaababababbmafafafbqbqbqbraFaFaFbrbrbrbraFaFabababababababababababababababababaa
-aaababababbmabafbmadadadadadbsadadadadadafababababababababababababababababababaa
-aaabababababababbmadauaubtbtauaububvbwadabababababababababababababababababababaa
-aaababababababababadadauauauauaubxaubwadabababababababababababababababababababaa
-aaabababababababababadadadbsadadadadadadabababababababababababababababababababaa
-aaabababababababababababadbybybybzadabababababababababababababababababababababaa
-aaabababababababababababadbAbAbAbBadabababababababababababababababababababababaa
-aaabababababababababababadbAbAbAbBadabababababababababababababababababababababaa
-aaabababababababababababadbAbAbAbAadabababababababababababababababababababababaa
-aaabababababababababababadbBbBbBbBadabababababababababababababababababababababaa
-aaabababababababababababadadadadadadabababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaacaaaaaaaaaaaaacaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaadaeaeaeafaaaaaaaaaaaaaaaaaaaaaeaeaaaaagagahaiajakaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaealamaeaaaaaaaaaaaaaaaaaaaeaeacahanaoapaqajajaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaeaeadaeaaaraaaaaaaaaaaaaaaaaaaeaeasatauatatavatajaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaeawataxayazatataAaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaababaaaaaaaaaaaaaaaaaaaaaaaaaaaeacasasacacasacacacaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaaaaaBaBaBaBaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaaaaaaaCaCaDaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaaaaaaaaaaaCaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaeaeaaaaaaaaaaaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaeaeaeaeaEaEaEaeaeaeaaaaaaaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaeaFaGaGaHaHaHaGaGaGaGaIaJaKaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaeaeaGaGaGaHaHaHaGaGaGaGaIaKaKaeaeaaaaaaaeaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaGaGaGaHaLaHaGaMaMaMaNaOaOaeaeaeaeaeaeaeaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaKaPaPaPaHaHaQaRaSaTaTaTaUaUaeaeaeaeaeaaaeaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaeaKaPaPaPaPaPaVaWaXaYaZaZaZaZaKaeaeaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaEaHaHaLaPaPbabbbcbdbdbdbdbeaKaeaeaeaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaeaEaEaEaEaKaKbfaGaNaNaNaNaNaOaKaeaeaeaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaeaEaEaEaEaKaKaPaGaNbgaNbhbhbiaOaEaeaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaEaEaEaHaPaPbjaGaNaNaNbhbhbiaOaEaebkblaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaeaGaPaPbmaEaOaOaObeaOaOaOaEaeaeblaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaeaeaGaPaPbnaEaEaEaEaEaEaEaEaEboboboaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaablaeaeaebpbpbpbqaEaEaEbqbqbqbqaEaEaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaablaaaeblacacacacacbracacacacacaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaablacatatbsbsatatbtbubvacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaacacatatatatatbwatbvacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaacacacbracacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaacbxbxbxbyacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaacbzbzbzbAacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaacbzbzbzbAacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaacbzbzbzbzacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaacbAbAbAbAacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -367,6 +367,7 @@ proc/process_ghost_teleport_locs()
 	name = "\improper Clown Planet"
 	icon_state = "honk"
 	requires_power = 0
+	has_gravity = 1
 
 /area/telesciareas
 	name = "\improper Cosmic Anomaly"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -103,8 +103,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/honker
 	name = "\improper HoNkER BlAsT 5000"
 	icon_state = "mecha_honker"
-	energy_drain = 200
-	equip_cooldown = 150
+	energy_drain = 600
+	equip_cooldown = 300
 	range = MELEE|RANGED
 	construction_time = 500
 	construction_cost = list("metal"=20000,"bananium"=10000)
@@ -120,21 +120,21 @@
 	set_ready_state(0)
 	playsound(chassis, 'sound/items/AirHorn.ogg', 100, 1)
 	chassis.occupant_message("<font color='red' size='5'>HONK</font>")
-	for(var/mob/living/carbon/M in ohearers(6, chassis))
+	for(var/mob/living/carbon/M in ohearers(3, chassis))
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
 				continue
 		M << "<font color='red' size='7'>HONK</font>"
 		M.sleeping = 0
-		M.stuttering += 20
-		M.ear_deaf += 30
-		M.Weaken(3)
-		if(prob(30))
-			M.Stun(10)
+		M.stuttering += 10
+		M.ear_deaf += 15
+		M.Weaken(2)
+		if(prob(15))
+			M.Stun(5)
 			M.Paralyse(4)
 		else
-			M.Jitter(500)
+			M.Jitter(250)
 		/* //else the mousetraps are useless
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -99,6 +99,8 @@
 					new/turf/simulated/floor/plating/asteroid/airless/cave(src)
 				if("Gibtonite")
 					M = new/turf/simulated/mineral/gibtonite(src)
+				if("Clown")
+					M = new/turf/simulated/mineral/clown(src)
 				/*if("Adamantine")
 					M = new/turf/simulated/mineral/adamantine(src)*/
 			if(M)
@@ -112,6 +114,15 @@
 	mineralSpawnChanceList = list("Uranium" = 10, "Iron" = 30, "Diamond" = 2, "Gold" = 10, "Silver" = 10, "Plasma" = 20)
 
 /turf/simulated/mineral/random/high_chance/New()
+	icon_state = "rock"
+	..()
+
+/turf/simulated/mineral/random/clown
+	icon_state = "rock_highchance"
+	mineralChance = 25
+	mineralSpawnChanceList = list("Clown" = 50)
+
+/turf/simulated/mineral/random/clown/New()
 	icon_state = "rock"
 	..()
 


### PR DESCRIPTION
We were promised clown planet as an away mission 3 years ago in the changelog when it got removed. Today is the day we get the clown planet.
http://i.imgur.com/OuvfnaB.png?1
Attempting to mine Bananium on the clown planet will make the local clowns go batshit due to you stealing their rightful minerals, so you gotta fight something to get your HONK mechs.

The HONKBlaster's stuns and deafens and weakens have been halved to balance it.
The HONKBlaster's charge drain has been doubled, along with the cooldown to balance it.
