### PR TITLE
Prevent generating culture bottles with no cooldown

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -645,6 +645,7 @@ obj/machinery/computer/pandemic/proc/replicator_cooldown(var/waittime)
 					D = new type(0, null)
 			if(!D)
 				return
+			replicator_cooldown(50)
 			var/list/data = list("viruses"=list(D))
 			var/name = sanitize(input(usr,"Name:","Name the culture",D.name))
 			if(!name || name == " ") name = D.name
@@ -652,7 +653,6 @@ obj/machinery/computer/pandemic/proc/replicator_cooldown(var/waittime)
 			B.desc = "A small bottle. Contains [D.agent] culture in synthblood medium."
 			B.reagents.add_reagent("blood",20,data)
 			src.updateUsrDialog()
-			replicator_cooldown(50)
 		else
 			src.temp_html = "The replicator is not ready yet."
 		src.updateUsrDialog()


### PR DESCRIPTION
I'm new to this so feel free to reject this request if I've screwed something up.

When using the PanD.E.M.I.C 2000 to create culture bottles, it pops up a dialog box asking you to name your culture.  If you ignore this dialog, you can go back to the other window and continue to click "create culture bottle" to keep making them with no cooldown.  The cooldown only kicks in after confirming the dialog box.  Moving the cooldown to before the dialog box fixes the issue.

Again, I'm new here so do with it what you will.  It's as much a test for the process of using git as anything else.  I'll make a post on the forums about this.
