### PR TITLE
Fixed Bible Snowflake

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -26,5 +26,11 @@ var/global/list/biblestates =		list("bible", "koran", "scrapbook", "burning", "h
 //Bible itemstates
 var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "bible", "bible", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
 
-//Bible deity names (Mainly stolen from 'famous' works of fiction)
-var/global/list/bibledeitynames = 	list("Space Jesus","Space Satan","Cthulu","Armok","Honk Mother","Gia","Beelzebub","Ymir","Zeus","Yog-Sothoth","Talos","Cuban Pete","Chaos","Slaanesh","Death","Drilldoizer","Astaruas","Bringer of Deep fryer","Gwyn","Flying Spaghetti Monster","The Force")
+//Bible deity names, Stolen from Fiction and gathered from the Players
+var/global/list/bibledeitynames = 	list("Space Jesus","Space Satan","Cthulu","Armok","Honk Mother","Gia","Beelzebub","Ymir","Zeus","Yog-Sothoth","Talos","Cuban Pete", \
+"Chaos","Slaanesh","Death","Drilldoizer","Astaruas","Bringer of Deep fryer","Gwyn","Flying Spaghetti Monster","The Force","Great Corgi","Mr Rogers","Old man Henderson", \
+"Galactus, Eater of Worlds","Gozer the Gozerian","Crom","The Q Continuum","Arceus","Eru Ilúvatar","Honk Father","Silencer", "Toolboxia","Bhaal","Comdomiom","God-king Boris")
+
+
+
+

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -12,3 +12,19 @@ var/timezoneOffset = 0 // The difference betwen midnight (of the host computer) 
 	// However it'd be ok to use for accessing attack logs and such too, which are even laggier.
 var/fileaccess_timer = 0
 
+
+///////////////////
+//  Bible Stuff  //
+///////////////////
+
+//Pretty bible names
+var/global/list/biblenames =		list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon")
+
+//Bible iconstates
+var/global/list/biblestates =		list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
+
+//Bible itemstates
+var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "bible", "bible", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
+
+//Bible deity names (Mainly stolen from 'famous' works of fiction)
+var/global/list/bibledeitynames = 	list("Space Jesus","Space Satan","Cthulu","Armok","Honk Mother","Gia","Beelzebub","Ymir","Zeus","Yog-Sothoth","Talos","Cuban Pete","Chaos","Slaanesh","Death","Drilldoizer","Astaruas","Bringer of Deep fryer","Gwyn","Flying Spaghetti Monster","The Force")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -18,11 +18,6 @@ var/global/datum/controller/gameticker/ticker
 
 	var/list/datum/mind/minds = list()//The people in the game. Used for objective tracking.
 
-	var/Bible_icon_state	// icon_state the chaplain has chosen for his bible
-	var/Bible_item_state	// item_state the chaplain has chosen for his bible
-	var/Bible_name			// name of the bible
-	var/Bible_deity_name
-
 	var/list/syndicate_coalition = list() // list of traitor-compatible factions
 	var/list/factions = list()			  // list of all factions
 	var/list/availablefactions = list()	  // list of factions with openings

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -13,15 +13,6 @@
 	minimal_access = list(access_morgue, access_chapel_office, access_crematorium)
 	assistant_access = list(access_chapel_office)
 
-	//Pretty bible names
-	var/global/list/biblenames =		list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon")
-
-	//Bible iconstates
-	var/global/list/biblestates =		list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
-
-	//Bible itemstates
-	var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "bible", "bible", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
-
 /datum/job/chaplain/proc/setupbiblespecifics(var/obj/item/weapon/storage/bible/B, var/mob/living/carbon/human/H)
 	switch(B.icon_state)
 		if("honk1","honk2")
@@ -67,10 +58,6 @@
 
 		usr.put_in_hands(B) // Update inhand icon
 
-		if(ticker)
-			ticker.Bible_icon_state = B.icon_state
-			ticker.Bible_item_state = B.item_state
-			ticker.Bible_name = B.name
 		feedback_set_details("religion_book","[biblename]")
 
 		usr << browse(null, "window=editicon") // Close window
@@ -126,8 +113,6 @@
 			new_deity = deity_name
 		B.deity_name = new_deity
 
-		if(ticker)
-			ticker.Bible_deity_name = B.deity_name
 		feedback_set_details("religion_deity","[new_deity]")
 
 		//Open bible selection

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -281,11 +281,11 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 				if(!bibledelay)
 
 					var/obj/item/weapon/storage/bible/B = new /obj/item/weapon/storage/bible(src.loc)
-					if(ticker && ( ticker.Bible_icon_state && ticker.Bible_item_state) )
-						B.icon_state = ticker.Bible_icon_state
-						B.item_state = ticker.Bible_item_state
-						B.name = ticker.Bible_name
-						B.deity_name = ticker.Bible_deity_name
+
+					B.icon_state = pick(biblestates)
+					B.item_state = pick(bibleitemstates)
+					B.name		 = pick(biblenames)
+					B.deity_name = pick(bibledeitynames)
 
 					bibledelay = 1
 					spawn(60)


### PR DESCRIPTION
Who put bible vars in the Gameticker?
Why would you put 1 item's references in the GAMETICKER?
I almost felt physically Ill when I found them.

These vars had one use, Making Library spawned bibles match the current bible, That reeks of Snowflake to me.
# NEW:

Library spawned Bibles randomise their iconstate, itemstate, name and deity name.
This does mean you will get mismatching names, deity names and icons but I think that's ok because you'll end up with some more "unique" religions and bibles from that.

Technically, this means you can no longer get your old bible back if it was destroyed, but then again, No other job unique items have any way to get them back, so screw you snowflake, Protect your bible better!

Moved the chaplain's "Global" bible lists to be real global vars, y'know, So you can actually access them globally! (This was required for the Library Bible Randomization)

Added a deity name list, Apparently we never had one and it's again needed for the Random bibles.
(I just stole a bunch from Games/Fiction/Myhead/Goofball's head)
