### PR TITLE
Fixes an AI Runtime.

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -37,7 +37,7 @@
 
 		//stage = 1
 		//if (istype(src, /mob/living/silicon/ai)) // Are we not sure what we are?
-		var/blind = 0
+		var/is_blind = 0
 		//stage = 2
 		var/area/loc = null
 		if (istype(T, /turf))
@@ -47,11 +47,11 @@
 				//stage = 4
 				if (!loc.master.power_equip && !istype(src.loc,/obj/item))
 					//stage = 5
-					blind = 1
+					is_blind = 1
 
-		if (!blind)
+		if (!is_blind)
 			//stage = 4.5
-			if (src.blind.layer != 0)
+			if (src.blind && src.blind.layer != 0)
 				src.blind.layer = 0
 			src.sight |= SEE_TURFS
 			src.sight |= SEE_MOBS


### PR DESCRIPTION
runtime error: Cannot read null.layer
proc name: Life (/mob/living/silicon/ai/Life)
  source file: life.dm,54
  usr: null
  src: AM (/mob/living/silicon/ai)
  call stack:
AM (/mob/living/silicon/ai): Life()
/datum/controller/game_control... (/datum/controller/game_controller): process mobs()
/datum/controller/game_control... (/datum/controller/game_controller): process()

Thanks to SoS for the Runtime logs.

As you can see, the cause of this is that the coder who wrote AI life() (Or added on the blindness part) Named a var "blind" which is already the name of the mob screen object, they probably though they'd sanity checked the screen object, because of seeing their Identically named var "blind"

That, or qdel() fucked the blind screen object up earlier on. Either way, Sanity checks are good.
