### PR TITLE
Hallucination Sting no longer lasts forever.

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -146,7 +146,7 @@ obj/effect/proc_holder/changeling/sting/LSD
 	add_logs(user, target, "stung", object="LSD sting")
 	spawn(rand(300,600))
 		if(target)
-			target.hallucination += 400
+			target.hallucination = max(target.hallucination, 400)
 	feedback_add_details("changeling_powers","HS")
 	return 1
 


### PR DESCRIPTION
Hallucination sting by itself seems fairly balanced; hallucination clears at a rate of 10 per Life() tick naturally; and chemicals can more than double that. As the sting deals only 400 hallucination, that's a mere 40 ticks _untreated_ - at most a minute or two with heavy server lag!

_However_, this sting results in episodes of hallucination lasting much, much longer than that. This, I believe, is due to the fact that repeated stings stack - allowing for hallucination levels to reach the thousands with ease.

Now, I've fixed that. Stings will no longer stack with each other (or with preexisting hallucinations for that matter).

My only concern is that this makes the hallucination sting _too weak_. I'm considering changing the level of hallucination it deals 600 (one BYOND minute untreated).
