### PR TITLE
Carp Befriending Stick

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -25,9 +25,10 @@
 	force = 0
 	
 	/obj/item/weapon/melee/carp_tamer/afterattack(atom/target, mob/user, proximity_flag)
-		if(istype(target, /mob/living/simple_animal/hostile/carp))
+		if(istype(target, /mob/living/simple_animal/hostile/carp) && proximity_flag)
 			var/mob/living/simple_animal/hostile/carp/M = target
 			M.friends += user
+			log_game("[user] has befriended a space carp with a carp tamer.")
 			user.visible_message("<span class='notice'>[user] smacks the Space Carp in the snout to establish superiority.</span>")
 		return
 

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -26,7 +26,7 @@
 	
 	/obj/item/weapon/melee/carp_tamer/afterattack(atom/target, mob/user, proximity_flag)
 		if(istype(target, /mob/living/simple_animal/hostile/carp) && proximity_flag)
-			var/mob/living/simple_animal/M = target
+			var/mob/living/simple_animal/hostile/M = target
 			M.friends += user
 			log_game("[user] has befriended a space carp with a carp tamer.")
 			user.visible_message("<span class='notice'>[user] smacks the Space Carp in the snout to establish superiority.</span>")

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -21,7 +21,7 @@
 	desc = "A highly advanced pheromone-coated stick that can be used to befriend Space Carp. Maybe."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "baton"
-	item_state = "carp_tamer"
+	item_state = "classic_baton"
 	force = 0
 	
 /obj/item/weapon/melee/carp_tamer/afterattack(atom/target, mob/user, proximity_flag)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -28,6 +28,7 @@
 		if(istype(target, /mob/living/simple_animal/hostile/carp))
 			var/mob/living/simple_animal/hostile/carp/M = target
 			M.friends += user
+			user.visible_message("<span class='notice'>[user] smacks the Space Carp in the snout to establish superiority.</span>")
 		return
 
 /obj/item/weapon/melee/classic_baton

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -26,7 +26,7 @@
 	
 	/obj/item/weapon/melee/carp_tamer/afterattack(atom/target, mob/user, proximity_flag)
 		if(istype(target, /mob/living/simple_animal/hostile/carp) && proximity_flag)
-			var/mob/living/simple_animal/hostile/carp/M = target
+			var/mob/living/simple_animal/M = target
 			M.friends += user
 			log_game("[user] has befriended a space carp with a carp tamer.")
 			user.visible_message("<span class='notice'>[user] smacks the Space Carp in the snout to establish superiority.</span>")

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -16,7 +16,19 @@
 		viewers(user) << "<span class='suicide'>[user] is strangling \himself with the [src.name]! It looks like \he's trying to commit suicide.</span>"
 		return (OXYLOSS)
 
-
+/obj/item/weapon/melee/carp_tamer
+	name = "carp befriending stick"
+	desc = "A highly advanced pheromone-coated stick that can be used to befriend Space Carp. Maybe."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "baton"
+	item_state = "carp_tamer"
+	force = 0
+	
+	/obj/item/weapon/melee/carp_tamer/afterattack(atom/target, mob/user, proximity_flag)
+		if(istype(target, /mob/living/simple_animal/hostile/carp))
+			var/mob/living/simple_animal/hostile/carp/M = target
+			M.friends += user
+		return
 
 /obj/item/weapon/melee/classic_baton
 	name = "police baton"

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -24,13 +24,13 @@
 	item_state = "carp_tamer"
 	force = 0
 	
-	/obj/item/weapon/melee/carp_tamer/afterattack(atom/target, mob/user, proximity_flag)
-		if(istype(target, /mob/living/simple_animal/hostile/carp) && proximity_flag)
-			var/mob/living/simple_animal/hostile/M = target
-			M.friends += user
-			log_game("[user] has befriended a space carp with a carp tamer.")
-			user.visible_message("<span class='notice'>[user] smacks the Space Carp in the snout to establish superiority.</span>")
-		return
+/obj/item/weapon/melee/carp_tamer/afterattack(atom/target, mob/user, proximity_flag)
+	if(istype(target, /mob/living/simple_animal/hostile/carp) && proximity_flag)
+		var/mob/living/simple_animal/hostile/M = target
+		M.friends += user
+		log_game("[user] has befriended a space carp with a carp tamer.")
+		user.visible_message("<span class='notice'>[user] smacks the Space Carp in the snout to establish superiority.</span>")
+	return
 
 /obj/item/weapon/melee/classic_baton
 	name = "police baton"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1877,6 +1877,15 @@ datum/design/welding_mask
 	build_type = PROTOLATHE
 	materials = list("$metal" = 4000, "$glass" = 2000)
 	build_path = /obj/item/clothing/mask/gas/welding
+	
+datum/design/carp_tamer
+	name = "Carp Befriending Stick"
+	desc = "A highly advanced pheromone-coated stick that can be used to befriend Space Carp. Maybe."
+	id = "carp_tamer"
+	req_tech = list("biotech" = 4, "materials" = 4)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 3000, "carpotoxin" = 10)
+	build_path = obj/item/weapon/melee/carp_tamer
 
 datum/design/mesons
 	name = "Optical Meson Scanners"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1885,7 +1885,7 @@ datum/design/carp_tamer
 	req_tech = list("biotech" = 4, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 3000, "carpotoxin" = 10)
-	build_path = obj/item/weapon/melee/carp_tamer
+	build_path = /obj/item/weapon/melee/carp_tamer
 
 datum/design/mesons
 	name = "Optical Meson Scanners"


### PR DESCRIPTION
This PR adds the Carp Befriendishment Stick. When you hit a carp with it, the carp won't attack you any more. It can be created in the Protolathe, but requires carpotoxin to do so.

Befriended carps still won't attack other carps.

Functions on holo-carp and laser-carp.

Poll located at http://tgstation13.org/phpBB/viewtopic.php?f=9&t=125&p=2591#p2591
Indicates a desire to see this in game.
