### PR TITLE
Update_icons() system improvement (Hand layers)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -87,10 +87,7 @@
 
 	if(W == A)
 		W.attack_self(src)
-		if(hand)
-			update_inv_l_hand(0)
-		else
-			update_inv_r_hand(0)
+		update_inv_hands(0)
 		return
 
 	// operate two levels deep here (item in backpack in src; NOT item in box in backpack in src)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -319,7 +319,6 @@
 			usr:swap_hand()
 		else
 			if(usr.attack_ui(slot_id))
-				usr.update_inv_l_hand(0)
-				usr.update_inv_r_hand(0)
+				usr.update_inv_hands(0)
 	return 1
 

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -22,12 +22,12 @@
 	if(istype(user.l_hand, /obj/item/weapon/melee/arm_blade)) //Not the nicest way to do it, but eh
 		qdel(user.l_hand)
 		user.visible_message("<span class='warning'>With a sickening crunch, [user] reforms his blade into an arm!</span>", "<span class='notice'>We assimilate our blade into our body</span>", "<span class='warning>You hear organic matter ripping and tearing!</span>")
-		user.update_inv_l_hand()
+		user.update_inv_hands()
 		return
 	if(istype(user.r_hand, /obj/item/weapon/melee/arm_blade))
 		qdel(user.r_hand)
 		user.visible_message("<span class='warning'>With a sickening crunch, [user] reforms his blade into an arm!</span>", "<span class='notice'>We assimilate our blade into our body</span>", "<span class='warning>You hear organic matter ripping and tearing!</span>")
-		user.update_inv_r_hand()
+		user.update_inv_hands()
 		return
 	..(user, target)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -359,12 +359,7 @@
 
 			if(active)
 				icon_state = "swordrainbow"
-				// Updating overlays, copied from welder code.
-				// I tried calling attack_self twice, which looked cool, except it somehow didn't update the overlays!!
-				if(user.r_hand == src)
-					user.update_inv_r_hand(0)
-				else if(user.l_hand == src)
-					user.update_inv_l_hand(0)
+				user.update_inv_hands(0)
 		else
 			user << "<span class='warning'>It's already fabulous!</span>"
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -173,8 +173,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(ismob(loc))
 			var/mob/M = loc
 			M.update_inv_wear_mask(0)
-			M.update_inv_l_hand(0)
-			M.update_inv_r_hand(0)
+			M.update_inv_hands(0)
 
 /obj/item/clothing/mask/cigarette/proc/handle_reagents()
 	if(iscarbon(loc))

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -123,13 +123,7 @@
 
 			if(active)
 				icon_state = "swordrainbow"
-				// Updating overlays, copied from welder code.
-				// I tried calling attack_self twice, which looked cool, except it somehow didn't update the overlays!!
-				if(user.r_hand == src)
-					user.update_inv_r_hand(0)
-				else if(user.l_hand == src)
-					user.update_inv_l_hand(0)
-
+				user.update_inv_hands(0)
 		else
 			user << "<span class='warning'>It's already fabulous!</span>"
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -45,8 +45,7 @@
 	user << "<span class='notice'>You fold [src] flat.</span>"
 	var/obj/item/I = new foldable(get_turf(src))
 	user.put_in_hands(I)
-	user.update_inv_l_hand()
-	user.update_inv_r_hand()
+	user.update_inv_hands()
 	qdel(src)
 
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -274,11 +274,7 @@
 		//mob icon update
 		if(ismob(loc))
 			var/mob/M = loc
-			if(M.r_hand == src)
-				M.update_inv_r_hand(0)
-			else if(M.l_hand == src)
-				M.update_inv_l_hand(0)
-
+			M.update_inv_hands(0)
 		return 0
 	return 1
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1293,9 +1293,9 @@
 				message_admins("[key_name(H)] has their hands full, so they did not receive their cookie, spawned by [key_name(src.owner)].")
 				return
 			else
-				H.update_inv_r_hand()//To ensure the icon appears in the HUD
+				H.update_inv_hands()//To ensure the icon appears in the HUD
 		else
-			H.update_inv_l_hand()
+			H.update_inv_hands()
 		log_admin("[key_name(H)] got their cookie, spawned by [key_name(src.owner)]")
 		message_admins("[key_name(H)] got their cookie, spawned by [key_name(src.owner)]")
 		feedback_inc("admin_cookies_spawned",1)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -25,7 +25,7 @@
 		W.equipped(src,slot_l_hand)
 		if(client)	client.screen |= W
 		if(pulling == W) stop_pulling()
-		update_inv_l_hand(0)
+		update_inv_hands(0)
 		return 1
 	return 0
 
@@ -42,7 +42,7 @@
 		W.equipped(src,slot_r_hand)
 		if(client)	client.screen |= W
 		if(pulling == W) stop_pulling()
-		update_inv_r_hand(0)
+		update_inv_hands(0)
 		return 1
 	return 0
 
@@ -114,10 +114,11 @@
 
 	if(I == r_hand)
 		r_hand = null
-		update_inv_r_hand()
+
 	else if(I == l_hand)
 		l_hand = null
-		update_inv_l_hand()
+
+	update_inv_hands()
 
 	if(I)
 		if(client)

--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -1,8 +1,7 @@
 //Xeno Overlays Indexes//////////
-#define X_L_HAND_LAYER			1
-#define X_R_HAND_LAYER			2
-#define X_FIRE_LAYER			3
-#define X_TOTAL_LAYERS			3
+#define X_HANDS_LAYER			1
+#define X_FIRE_LAYER			2
+#define X_TOTAL_LAYERS			2
 /////////////////////////////////
 
 /mob/living/carbon/alien/humanoid
@@ -31,8 +30,7 @@
 	..()
 	if (notransform)	return
 
-	update_inv_r_hand(0)
-	update_inv_l_hand(0)
+	update_inv_hands(0)
 	update_inv_pockets(0)
 	update_hud()
 //	update_icons() //Handled in update_transform(), leaving this here as a reminder
@@ -60,28 +58,29 @@
 	if(update_icons)
 		update_icons()
 
+/mob/living/carbon/alien/humanoid/update_inv_hands(update_icons = 1)
+	var/list/X_hands_overlays = list()
 
-/mob/living/carbon/alien/humanoid/update_inv_r_hand(update_icons = 1)
-	if(r_hand)
-		var/t_state = r_hand.item_state
-		if(!t_state)
-			t_state = r_hand.icon_state
-		r_hand.screen_loc = ui_rhand
-		overlays_standing[X_R_HAND_LAYER]	= image("icon" = 'icons/mob/items_righthand.dmi', "icon_state" = t_state)
-	else
-		overlays_standing[X_R_HAND_LAYER]	= null
-	if(update_icons)
-		update_icons()
-
-/mob/living/carbon/alien/humanoid/update_inv_l_hand(update_icons = 1)
 	if(l_hand)
 		var/t_state = l_hand.item_state
 		if(!t_state)
 			t_state = l_hand.icon_state
 		l_hand.screen_loc = ui_lhand
-		overlays_standing[X_L_HAND_LAYER]	= image("icon" = 'icons/mob/items_lefthand.dmi', "icon_state" = t_state)
-	else
-		overlays_standing[X_L_HAND_LAYER]	= null
+		X_hands_overlays	+= image("icon" = 'icons/mob/items_lefthand.dmi', "icon_state" = t_state)
+
+	if(r_hand)
+		var/t_state = r_hand.item_state
+		if(!t_state)
+			t_state = r_hand.icon_state
+		r_hand.screen_loc = ui_rhand
+		X_hands_overlays	+= image("icon" = 'icons/mob/items_righthand.dmi', "icon_state" = t_state)
+
+	if(X_hands_overlays.len)
+		overlays_standing[X_HANDS_LAYER] = X_hands_overlays
+		var/image/I = overlays_standing[X_HANDS_LAYER]
+		if(I)
+			overlays += I
+
 	if(update_icons)
 		update_icons()
 
@@ -95,7 +94,6 @@
 		overlays_standing[X_FIRE_LAYER] = null
 
 //Xeno Overlays Indexes//////////
-#undef X_L_HAND_LAYER
-#undef X_R_HAND_LAYER
+#undef X_HANDS_LAYER
 #undef X_FIRE_LAYER
 #undef X_TOTAL_LAYERS

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -10,10 +10,7 @@
 			H << "<span class='notice'>You are not holding anything to equip.</span>"
 			return
 		if(H.equip_to_appropriate_slot(I))
-			if(hand)
-				update_inv_l_hand(0)
-			else
-				update_inv_r_hand(0)
+			update_inv_hands(0)
 		else if(s_active && s_active.can_be_inserted(I,1))	//if storage active insert there
 			s_active.handle_item_insertion(I)
 		else if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))	//see if we have box in other hand
@@ -181,10 +178,10 @@
 			update_inv_legcuffed(redraw_mob)
 		if(slot_l_hand)
 			l_hand = I
-			update_inv_l_hand(redraw_mob)
+			update_inv_hands(redraw_mob)
 		if(slot_r_hand)
 			r_hand = I
-			update_inv_r_hand(redraw_mob)
+			update_inv_hands(redraw_mob)
 		if(slot_belt)
 			belt = I
 			update_inv_belt(redraw_mob)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -5,7 +5,7 @@
 This system allows you to update individual mob-overlays, without regenerating them all each time.
 When we generate overlays we generate the standing version and then rotate the mob as necessary..
 
-As of the time of writing there are 20 layers within this list. Please try to keep this from increasing. //22 and counting, good job guys
+As of the time of writing there are 20 layers within this list. Please try to keep this from increasing. //21 Total, Keeping things simple
 	var/overlays_standing[20]		//For the standing stance
 
 Most of the time we only wish to update one overlay:
@@ -13,7 +13,7 @@ Most of the time we only wish to update one overlay:
 	e.g.2 - our hair colour has changed, so we need to update our hair icons on our mob
 In these cases, instead of updating every overlay using the old behaviour (regenerate_icons), we instead call
 the appropriate update_X proc.
-	e.g. - update_l_hand()
+	e.g. - update_inv_hands()
 	e.g.2 - update_hair()
 
 Note: Recent changes by aranclanos+carn:
@@ -56,29 +56,28 @@ Please contact me on #coderbus IRC. ~Carnie x
 */
 
 //Human Overlays Indexes/////////
-#define BODY_LAYER				22		//underwear, undershirts, eyes, lips(makeup)
-#define MUTATIONS_LAYER			21		//Tk headglows etc.
-#define AUGMENTS_LAYER			20
-#define DAMAGE_LAYER			19		//damage indicators (cuts and burns)
-#define UNIFORM_LAYER			18
-#define ID_LAYER				17
-#define SHOES_LAYER				16
-#define GLOVES_LAYER			15
-#define EARS_LAYER				14
-#define SUIT_LAYER				13
-#define GLASSES_LAYER			12
-#define BELT_LAYER				11		//Possible make this an overlay of somethign required to wear a belt?
-#define SUIT_STORE_LAYER		10
-#define BACK_LAYER				9
-#define HAIR_LAYER				8		//TODO: make part of head layer?
-#define FACEMASK_LAYER			7
-#define HEAD_LAYER				6
-#define HANDCUFF_LAYER			5
-#define LEGCUFF_LAYER			4
-#define L_HAND_LAYER			3
-#define R_HAND_LAYER			2		//Having the two hands seperate seems rather silly, merge them together? It'll allow for code to be reused on mobs with arbitarily many hands
+#define BODY_LAYER				21		//underwear, undershirts, eyes, lips(makeup)
+#define MUTATIONS_LAYER			20		//Tk headglows etc.
+#define AUGMENTS_LAYER			19
+#define DAMAGE_LAYER			18		//damage indicators (cuts and burns)
+#define UNIFORM_LAYER			17
+#define ID_LAYER				16
+#define SHOES_LAYER				15
+#define GLOVES_LAYER			14
+#define EARS_LAYER				13
+#define SUIT_LAYER				12
+#define GLASSES_LAYER			11
+#define BELT_LAYER				10		//Possible make this an overlay of somethign required to wear a belt?
+#define SUIT_STORE_LAYER		9
+#define BACK_LAYER				8
+#define HAIR_LAYER				7		//Seperate layer so head items can overlay Hair and Hair underlay head items
+#define FACEMASK_LAYER			6
+#define HEAD_LAYER				5
+#define HANDCUFF_LAYER			4
+#define LEGCUFF_LAYER			3
+#define HANDS_LAYER				2
 #define FIRE_LAYER				1		//If you're on fire
-#define TOTAL_LAYERS			22		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
+#define TOTAL_LAYERS			21		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
 //////////////////////////////////
 /mob/living/carbon/human
 	var/list/overlays_standing[TOTAL_LAYERS]
@@ -301,8 +300,7 @@ Please contact me on #coderbus IRC. ~Carnie x
 	update_inv_belt()
 	update_inv_back()
 	update_inv_wear_suit()
-	update_inv_r_hand()
-	update_inv_l_hand()
+	update_inv_hands()
 	update_inv_handcuffed()
 	update_inv_legcuffed()
 	update_inv_pockets()
@@ -621,42 +619,38 @@ Please contact me on #coderbus IRC. ~Carnie x
 	apply_overlay(LEGCUFF_LAYER)
 
 
+/mob/living/carbon/human/update_inv_hands()
+	var/list/H_hands_overlays = list()
 
-/mob/living/carbon/human/update_inv_r_hand()
-	remove_overlay(R_HAND_LAYER)
-	if (handcuffed)
-		drop_r_hand()
-		return
-	if(r_hand)
-		if(client)
-			r_hand.screen_loc = ui_rhand	//TODO
-			client.screen += r_hand
+	remove_overlay(HANDS_LAYER)
 
-		var/t_state = r_hand.item_state
-		if(!t_state)	t_state = r_hand.icon_state
-
-		overlays_standing[R_HAND_LAYER] = image("icon"='icons/mob/items_righthand.dmi', "icon_state"="[t_state]", "layer"=-R_HAND_LAYER)
-
-	apply_overlay(R_HAND_LAYER)
-
-
-
-/mob/living/carbon/human/update_inv_l_hand()
-	remove_overlay(L_HAND_LAYER)
-	if (handcuffed)
+	if(handcuffed)
 		drop_l_hand()
+		drop_r_hand()
 		return
 	if(l_hand)
 		if(client)
-			l_hand.screen_loc = ui_lhand	//TODO
+			l_hand.screen_loc = ui_lhand
 			client.screen += l_hand
 
 		var/t_state = l_hand.item_state
 		if(!t_state)	t_state = l_hand.icon_state
 
-		overlays_standing[L_HAND_LAYER] = image("icon"='icons/mob/items_lefthand.dmi', "icon_state"="[t_state]", "layer"=-L_HAND_LAYER)
+		H_hands_overlays += image("icon"='icons/mob/items_lefthand.dmi', "icon_state"="[t_state]", "layer"=-HANDS_LAYER)
+	if(r_hand)
+		if(client)
+			r_hand.screen_loc = ui_rhand
+			client.screen += r_hand
 
-	apply_overlay(L_HAND_LAYER)
+		var/t_state = r_hand.item_state
+		if(!t_state)	t_state = r_hand.icon_state
+
+		H_hands_overlays += image("icon"='icons/mob/items_righthand.dmi', "icon_state"="[t_state]", "layer"=-HANDS_LAYER)
+
+	if(H_hands_overlays.len)
+		overlays_standing[HANDS_LAYER] = H_hands_overlays
+
+	apply_overlay(HANDS_LAYER)
 
 //Human Overlays Indexes/////////
 #undef BODY_LAYER
@@ -677,7 +671,6 @@ Please contact me on #coderbus IRC. ~Carnie x
 #undef HEAD_LAYER
 #undef HANDCUFF_LAYER
 #undef LEGCUFF_LAYER
-#undef L_HAND_LAYER
-#undef R_HAND_LAYER
+#undef HANDS_LAYER
 #undef FIRE_LAYER
 #undef TOTAL_LAYERS

--- a/code/modules/mob/living/carbon/monkey/inventory.dm
+++ b/code/modules/mob/living/carbon/monkey/inventory.dm
@@ -28,11 +28,11 @@
 		if(slot_l_hand)
 			l_hand = I
 			I.equipped(src, slot)
-			update_inv_l_hand(redraw_mob)
+			update_inv_hands(redraw_mob)
 		if(slot_r_hand)
 			r_hand = I
 			I.equipped(src, slot)
-			update_inv_r_hand(redraw_mob)
+			update_inv_hands(redraw_mob)
 		if(slot_in_backpack)
 			if(I == get_active_hand())
 				unEquip(I)

--- a/code/modules/mob/living/carbon/monkey/update_icons.dm
+++ b/code/modules/mob/living/carbon/monkey/update_icons.dm
@@ -1,11 +1,10 @@
 //Monkey Overlays Indexes////////
-#define M_FIRE_LAYER			6
-#define M_MASK_LAYER			5
-#define M_BACK_LAYER			4
-#define M_HANDCUFF_LAYER		3
-#define M_L_HAND_LAYER			2
-#define M_R_HAND_LAYER			1
-#define M_TOTAL_LAYERS			6
+#define M_FIRE_LAYER			5
+#define M_MASK_LAYER			4
+#define M_BACK_LAYER			3
+#define M_HANDCUFF_LAYER		2
+#define M_HANDS_LAYER			1
+#define M_TOTAL_LAYERS			5
 /////////////////////////////////
 
 /mob/living/carbon/monkey
@@ -15,8 +14,7 @@
 	..()
 	update_inv_wear_mask(0)
 	update_inv_back(0)
-	update_inv_r_hand(0)
-	update_inv_l_hand(0)
+	update_inv_hands(0)
 	update_inv_handcuffed(0)
 	update_fire()
 	update_icons()
@@ -50,43 +48,40 @@
 	if(update_icons)		update_icons()
 
 
-/mob/living/carbon/monkey/update_inv_r_hand(var/update_icons=1)
-	if (handcuffed)
+/mob/living/carbon/monkey/update_inv_hands(var/update_icons = 1)
+	var/list/M_overlays = list()
+
+	if(handcuffed)
 		drop_r_hand()
+		drop_l_hand()
 		return
+
 	if(r_hand)
 		r_hand.screen_loc = ui_rhand
 		if(client && hud_used)
 			client.screen += r_hand
 		var/t_state = r_hand.item_state
 		if(!t_state)	t_state = r_hand.icon_state
-		overlays -= overlays_standing[M_R_HAND_LAYER]
-		overlays_standing[M_R_HAND_LAYER]	= image("icon" = 'icons/mob/items_righthand.dmi', "icon_state" = t_state, "layer" = -M_R_HAND_LAYER)
-		overlays += overlays_standing[M_R_HAND_LAYER]
-	else
-		overlays -= overlays_standing[M_R_HAND_LAYER]
-		overlays_standing[M_R_HAND_LAYER]	= null
-	if(update_icons)		update_icons()
+		overlays -= overlays_standing[M_HANDS_LAYER]
+		M_overlays	+= image("icon" = 'icons/mob/items_righthand.dmi', "icon_state" = t_state, "layer" = -M_HANDS_LAYER)
 
-
-/mob/living/carbon/monkey/update_inv_l_hand(var/update_icons=1)
-	if (handcuffed)
-		drop_l_hand()
-		return
 	if(l_hand)
 		l_hand.screen_loc = ui_lhand
 		if(client && hud_used)
 			client.screen += l_hand
 		var/t_state = l_hand.item_state
 		if(!t_state)	 t_state = l_hand.icon_state
-		overlays -= overlays_standing[M_L_HAND_LAYER]
-		overlays_standing[M_L_HAND_LAYER]	= image("icon" = 'icons/mob/items_lefthand.dmi', "icon_state" = t_state, "layer" = -M_L_HAND_LAYER)
-		overlays += overlays_standing[M_L_HAND_LAYER]
-	else
-		overlays -= overlays_standing[M_L_HAND_LAYER]
-		overlays_standing[M_L_HAND_LAYER]	= null
-	if(update_icons)		update_icons()
+		overlays -= overlays_standing[M_HANDS_LAYER]
+		M_overlays	+= image("icon" = 'icons/mob/items_lefthand.dmi', "icon_state" = t_state, "layer" = -M_HANDS_LAYER)
 
+	if(M_overlays.len)
+		overlays_standing[M_HANDS_LAYER] = M_overlays
+		var/image/I = overlays_standing[M_HANDS_LAYER]
+		if(I)
+			overlays += I
+
+	if(update_icons)
+		update_icons()
 
 /mob/living/carbon/monkey/update_inv_back(var/update_icons=1)
 	if(back)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -265,12 +265,12 @@ var/list/slot_equipment_priority = list( \
 		var/obj/item/W = l_hand
 		if (W)
 			W.attack_self(src)
-			update_inv_l_hand(0)
+			update_inv_hands(0)
 	else
 		var/obj/item/W = r_hand
 		if (W)
 			W.attack_self(src)
-			update_inv_r_hand(0)
+			update_inv_hands(0)
 	return
 
 /*

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -22,10 +22,7 @@
 /mob/proc/update_inv_back()
 	return
 
-/mob/proc/update_inv_l_hand()
-	return
-
-/mob/proc/update_inv_r_hand()
+/mob/proc/update_inv_hands()
 	return
 
 /mob/proc/update_inv_wear_mask()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -93,8 +93,5 @@
 		process_chamber()
 		update_icon()
 
-		if(user.hand)
-			user.update_inv_l_hand(0)
-		else
-			user.update_inv_r_hand(0)
+		user.update_inv_hands(0)
 


### PR DESCRIPTION
Removes both hand layers and adds a single Hand layer for each mob.
Replaces both update_inv_BLAH_hand() procs with update_inv_hands()

The affected mobs are as follows:
- Humans - [Tested]
- Monkeys - [Tested]
- Xenomorphs - [Tested]

This puts us a little bit closer to mobs having more than 2 hands!
