### PR TITLE
Adds a confirmation prompt to put a BoH in a BoH

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -48,8 +48,7 @@
 			if(confirm == "No")
 				return
 			investigate_log("has become a singularity. Caused by [user.key]","singulo")
-			user << "\red The Bluespace interfaces of the two devices catastrophically malfunction!"
-			qdel(W)
+			user << "<span class='notice'> The Bluespace interfaces of the two devices catastrophically malfunction!</span>"			qdel(W)
 			var/obj/machinery/singularity/singulo = new /obj/machinery/singularity (get_turf(src))
 			singulo.energy = 300 //should make it a bit bigger~
 			message_admins("[key_name_admin(user)] detonated a bag of holding")
@@ -61,9 +60,9 @@
 	proc/failcheck(mob/user as mob)
 		if (prob(src.reliability)) return 1 //No failure
 		if (prob(src.reliability))
-			user << "\red The Bluespace portal resists your attempt to add another item." //light failure
+			user << "<span class='notice'> The Bluespace portal resists your attempt to add another item.</span>" //light failure
 		else
-			user << "\red The Bluespace generator malfunctions!"
+			user << "<span class='notice'> The Bluespace generator malfunctions!</span>"
 			for (var/obj/O in src.contents) //it broke, delete what was in it
 				qdel(O)
 			crit_fail = 1

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -44,6 +44,9 @@
 			user << "\red The Bluespace generator isn't working."
 			return
 		if(istype(W, /obj/item/weapon/storage/backpack/holding) && !W.crit_fail)
+			var/confirm = input("Are you sure you want to do that?", "Put in Bag of Holding") in list("Yes", "No")
+			if(confirm == "No")
+				return
 			investigate_log("has become a singularity. Caused by [user.key]","singulo")
 			user << "\red The Bluespace interfaces of the two devices catastrophically malfunction!"
 			qdel(W)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -48,7 +48,8 @@
 			if(confirm == "No")
 				return
 			investigate_log("has become a singularity. Caused by [user.key]","singulo")
-			user << "<span class='notice'> The Bluespace interfaces of the two devices catastrophically malfunction!</span>"			qdel(W)
+			user << "<span class='notice'> The Bluespace interfaces of the two devices catastrophically malfunction!</span>"
+			qdel(W)
 			var/obj/machinery/singularity/singulo = new /obj/machinery/singularity (get_turf(src))
 			singulo.energy = 300 //should make it a bit bigger~
 			message_admins("[key_name_admin(user)] detonated a bag of holding")

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -41,7 +41,7 @@
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(crit_fail)
-			user << "\red The Bluespace generator isn't working."
+			user << "<span class = 'notice'>The Bluespace generator isn't working.</span>"
 			return
 		if(istype(W, /obj/item/weapon/storage/backpack/holding) && !W.crit_fail)
 			var/confirm = input("Are you sure you want to do that?", "Put in Bag of Holding") in list("Yes", "No")


### PR DESCRIPTION
There's been significant complains that due to the removed click delay, it's too easy to accidentally detonate Bags of Holding. This adds a confirmation prompt to doing so. The prompt does not explicitly state what will happen.
