### PR TITLE
Default click behavior for ghost changed to not examine everything

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -1,4 +1,4 @@
-/client/var/inquisitive_ghost = 1
+/client/var/inquisitive_ghost = 0
 /mob/dead/observer/verb/toggle_inquisition() // warning: unexpected inquisition
 	set name = "Toggle Inquisitiveness"
 	set desc = "Sets whether your ghost examines everything on click by default"


### PR DESCRIPTION
Default behavior for ghost clicking changed so they no longer examine everything on click by default

Changes default behavior for ghost inquisitiveness to not examine everything when you click on it. Toggle inquisitiveness still exists to enable or disable whether clicking on stuff auto-examines. 

Shift-click obviously still always works to examine stuff irrespective of ghost inquisitiveness.
