### PR TITLE
Introducing the Hostile Lockdown ability for AI Malfunction!

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -72,9 +72,7 @@
 
 	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
 		spawn()
-			if(FA.lockdownbyai == 0)
-				FA.lockdownbyai = 1
-				FA.alarm()
+			FA.alarm()
 	for(var/obj/machinery/door/poddoor/BD in world) //Close blast doors!
 		spawn()
 			BD.close()
@@ -105,9 +103,7 @@
 
 	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
 		spawn()
-			if(FA.lockdownbyai == 1)
-				FA.lockdownbyai = 0
-				FA.reset()
+			FA.reset()
 	for(var/obj/machinery/door/poddoor/BD in world) //Open blast doors!
 		spawn()
 			BD.open()

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -80,7 +80,7 @@
 			BD.close()
 	for(var/obj/machinery/door/airlock/AL in world) //shock-bolt airlocks
 		spawn()
-			if(AL.canAIControl())
+			if(AL.canAIControl() && !AL.stat) //Must be powered and have working AI wire.
 				AL.locked = 0
 				AL.safe = 0
 				AL.close()
@@ -113,7 +113,7 @@
 			BD.open()
 	for(var/obj/machinery/door/airlock/AL in world) //unbolt and open airlocks
 		spawn()
-			if(AL.canAIControl())
+			if(AL.canAIControl() && !AL.stat)
 
 				AL.locked = 0
 				AL.secondsElectrified = 0

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -66,8 +66,8 @@
 	set category = "Malfunction"
 	set name = "Initiate Hostile Lockdown"
 
-	if(usr.stat == 2)
-		usr <<"You cannot begin a lockdown because you are dead!"
+	if(src.stat == 2)
+		src <<"You cannot begin a lockdown because you are dead!"
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
@@ -99,8 +99,8 @@
 	set category = "Malfunction"
 	set name = "Disable Lockdown"
 
-	if(usr.stat == 2)
-		usr <<"You cannot disable lockdown because you are dead!"
+	if(src.stat == 2)
+		src <<"You cannot disable lockdown because you are dead!"
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
@@ -121,7 +121,7 @@
 				AL.safe = 1
 				AL.lights = 1
 
-	usr << "<span class = 'notice'>Lockdown Lifted.</span>"
+	src << "<span class = 'notice'>Lockdown Lifted.</span>"
 
 /datum/AI_Module/large/disable_rcd
 	module_name = "RCD disable"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -93,7 +93,7 @@
 		C.post_status("alert", "lockdown")
 
 	src.verbs += /mob/living/silicon/ai/proc/disablelockdown
-	usr << "<span class = 'warning'>Lockdown Initiated.</span>"
+	src << "<span class = 'warning'>Lockdown Initiated.</span>"
 
 /mob/living/silicon/ai/proc/disablelockdown()
 	set category = "Malfunction"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -53,6 +53,76 @@
 		turret.shot_delay = 20
 	src << "<span class='notice'>Turrets upgraded.</span>"
 
+/datum/AI_Module/large/lockdown
+	module_name = "Hostile Station Lockdown"
+	mod_pick_name = "lockdown"
+	description = "Take control of the airlock, blast door and fire control networks, locking them down. Caution! This command also electrifies all airlocks."
+	cost = 20
+	one_time = 1
+
+	power_type = /mob/living/silicon/ai/proc/lockdown
+
+/mob/living/silicon/ai/proc/lockdown()
+	set category = "Malfunction"
+	set name = "Initiate Hostile Lockdown"
+
+	if(usr.stat == 2)
+		usr <<"You cannot begin a lockdown because you are dead!"
+		return
+
+	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
+		spawn()
+			if(FA.lockdownbyai == 0)
+				FA.lockdownbyai = 1
+				FA.alarm()
+	for(var/obj/machinery/door/poddoor/BD in world) //Close blast doors!
+		spawn()
+			BD.close()
+	for(var/obj/machinery/door/airlock/AL in world) //shock-bolt airlocks
+		spawn()
+			if(AL.canAIControl())
+				AL.locked = 0
+				AL.safe = 0
+				AL.close()
+				AL.locked = 1
+				AL.lights = 0
+				AL.secondsElectrified = -1
+
+	var/obj/machinery/computer/communications/C = locate() in world
+	if(C)
+		C.post_status("alert", "lockdown")
+
+	src.verbs += /mob/living/silicon/ai/proc/disablelockdown
+	usr << "<span class = 'warning'>Lockdown Initiated.</span>"
+
+/mob/living/silicon/ai/proc/disablelockdown()
+	set category = "Malfunction"
+	set name = "Disable Lockdown"
+
+	if(usr.stat == 2)
+		usr <<"You cannot disable lockdown because you are dead!"
+		return
+
+	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
+		spawn()
+			if(FA.lockdownbyai == 1)
+				FA.lockdownbyai = 0
+				FA.reset()
+	for(var/obj/machinery/door/poddoor/BD in world) //Open blast doors!
+		spawn()
+			BD.open()
+	for(var/obj/machinery/door/airlock/AL in world) //unbolt and open airlocks
+		spawn()
+			if(AL.canAIControl())
+
+				AL.locked = 0
+				AL.secondsElectrified = 0
+				AL.open()
+				AL.safe = 1
+				AL.lights = 1
+
+	usr << "<span class = 'notice'>Lockdown Lifted.</span>"
+
 /datum/AI_Module/large/disable_rcd
 	module_name = "RCD disable"
 	mod_pick_name = "rcd"


### PR DESCRIPTION
Grants a Malf AI a new ability - Hostile Lockdown, costing 20 CPU time.
- This ability activates all firelocks
- Closes all blast doors and shutters
- Closes and shock-bolts all airlocks that the AI can control, crushing anyone standing in a doorway when it happens.
- Sets the screen display to "Lockdown"

The lockdown can be reversed using the "Disable Lockdown" verb.
- Lifting the lockdown opens everything that was locked down by the AI. (Airlocks close again shortly after)
- Lifting the lockdown restores airlocks to a safe and functional setting.

Justification for this ability provided here: http://www.ss13.eu/tgdb/tg/latest_stats.html#mode_AI_malfunction

Discussion and poll relating to this update located here: 
http://tgstation13.org/phpBB/viewtopic.php?f=14&t=284

/tg/ PR version found here: https://github.com/tgstation/-tg-station/pull/3421
