### PR TITLE
Engineers know Door and APC wires from Round start [Merge]

### DIFF
--- a/NTstation13.dme
+++ b/NTstation13.dme
@@ -586,6 +586,7 @@
 #include "code\game\objects\items\weapons\implants\implantchair.dm"
 #include "code\game\objects\items\weapons\implants\implanter.dm"
 #include "code\game\objects\items\weapons\implants\implantfreedom.dm"
+#include "code\game\objects\items\weapons\implants\implantknowledge.dm"
 #include "code\game\objects\items\weapons\implants\implantpad.dm"
 #include "code\game\objects\items\weapons\implants\implantuplink.dm"
 #include "code\game\objects\items\weapons\melee\energy.dm"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -445,6 +445,12 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
 	cost = 4
 
+/datum/uplink_item/implants/wire_kit_doors
+	name = "Wire Knowledge: Doors"
+	desc = "An implant granting you the knowledge of Non-secure Airlock and Door wire systems"
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_wire_door
+	cost = 2 //2 because unlike the Emag, this needs tools
+
 // POINTLESS BADASSERY
 
 /datum/uplink_item/badass

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -195,3 +195,34 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = !A.lights
 			A.update_icon()
+
+
+/datum/wires/airlock/SolveWireFunction(var/function)
+	var/sf = ""
+	switch(function)
+		if(AIRLOCK_WIRE_IDSCAN)
+			sf = "ID wire"
+		if(AIRLOCK_WIRE_MAIN_POWER1)
+			sf = "1st Main Power wire"
+		if(AIRLOCK_WIRE_MAIN_POWER2)
+			sf = "2nd Main Power wire"
+		if(AIRLOCK_WIRE_DOOR_BOLTS)
+			sf = "Door Bolts wire"
+		if(AIRLOCK_WIRE_BACKUP_POWER1)
+			sf = "1st Backup Power wire"
+		if(AIRLOCK_WIRE_BACKUP_POWER2)
+			sf = "2nd Backup Power wire"
+		if(AIRLOCK_WIRE_OPEN_DOOR)
+			sf = "Open Door wire"
+		if(AIRLOCK_WIRE_AI_CONTROL)
+			sf = "AI Control wire"
+		if(AIRLOCK_WIRE_ELECTRIFY)
+			sf = "Electrify Door wire"
+		if(AIRLOCK_WIRE_SAFETY)
+			sf = "Safety wire"
+		if(AIRLOCK_WIRE_SPEED)
+			sf = "Door Speed wire"
+		if(AIRLOCK_WIRE_LIGHT)
+			sf = "Lights wire"
+
+	return sf

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -76,3 +76,19 @@ var/const/APC_WIRE_AI_CONTROL = 8
 				if (A.aidisabled == 1)
 					A.aidisabled = 0
 	A.updateDialog()
+
+
+/datum/wires/apc/SolveWireFunction(var/function)
+	var/sf = ""
+	switch(function)
+		if(APC_WIRE_IDSCAN)
+			sf = "ID wire"
+		if(APC_WIRE_MAIN_POWER1)
+			sf = "1st Main Power wire"
+		if(APC_WIRE_MAIN_POWER2)
+			sf = "2nd Main Power wire"
+		if(APC_WIRE_AI_CONTROL)
+			sf = "AI Control wire"
+
+	return sf
+

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -1,13 +1,12 @@
 /datum/wires/robot
 	random = 1
 	holder_type = /mob/living/silicon/robot
-	wire_count = 5
+	wire_count = 4
 
 var/const/BORG_WIRE_LAWCHECK = 1
-var/const/BORG_WIRE_MAIN_POWER = 2 // The power wires do nothing whyyyyyyyyyyyyy
-var/const/BORG_WIRE_LOCKED_DOWN = 4
-var/const/BORG_WIRE_AI_CONTROL = 8
-var/const/BORG_WIRE_CAMERA = 16
+var/const/BORG_WIRE_LOCKED_DOWN = 2
+var/const/BORG_WIRE_AI_CONTROL = 4
+var/const/BORG_WIRE_CAMERA = 8
 
 /datum/wires/robot/GetInteractWindow()
 
@@ -80,3 +79,19 @@ var/const/BORG_WIRE_CAMERA = 16
 
 /datum/wires/robot/proc/LockedCut()
 	return wires_status & BORG_WIRE_LOCKED_DOWN
+
+/datum/wires/robot/SolveWireFunction(var/function)
+	var/sf = ""
+	switch(function)
+		if(BORG_WIRE_LAWCHECK)
+			sf = "Law Check wire"
+		if(BORG_WIRE_LOCKED_DOWN)
+			sf = "Lockdown wire"
+		if(BORG_WIRE_AI_CONTROL)
+			sf = "AI Control wire"
+		if(BORG_WIRE_CAMERA)
+			sf = "Camera wire"
+
+	return sf
+
+

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -9,6 +9,8 @@ var/list/same_wires = list()
 // 12 colours, if you're adding more than 12 wires then add more colours here
 var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", "gold", "gray", "cyan", "navy", "purple", "pink")
 
+var/global/all_solved_wires = list() //Solved wire associative list, eg; all_solved_wires[/obj/machinery/door/airlock]
+
 /datum/wires
 
 	var/random = 0 // Will the wires be different for every single instance.
@@ -25,6 +27,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 	var/row_options2 = " width='260px'"
 	var/window_x = 370
 	var/window_y = 470
+
 
 /datum/wires/New(var/atom/holder)
 	..()
@@ -45,6 +48,11 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 		else
 			var/list/wires = same_wires[holder_type]
 			src.wires = wires // Reference the wires list.
+
+	if(random) //Secure/Random wires do not get Solved
+		return
+
+	all_solved_wires[holder_type] = SolveWires()
 
 /datum/wires/proc/GenerateWires()
 	var/list/colours_to_pick = wireColours.Copy() // Get a copy, not a reference.
@@ -291,3 +299,53 @@ var/const/POWER = 8
 /datum/wires/proc/Shuffle()
 	wires_status = 0
 	GenerateWires()
+
+
+//
+//Translates each individual UNIQUE wire datum (Eg: APC, AIRLOCK)
+//From their Bitflag meanings to their Written fucntion (Eg: 256 = Bolts)
+//Requires overwriting on each individual unique wire datum
+//
+
+/datum/wires/proc/SolveWireFunction(var/WireFunction)
+	return WireFunction //Default returns the original number, so it still "works"
+
+//
+//Works out a name by the type of the holder
+//To "Pretty" up the SolveWires() output
+//
+
+/datum/wires/proc/name_by_type()
+	var/name_by_type
+	if(istype(src, /datum/wires/airlock))
+		name_by_type = "Airlock"
+	if(istype(src, /datum/wires/apc))
+		name_by_type = "APC"
+	if(istype(src, /datum/wires/robot))
+		name_by_type = "Cyborg"
+	return name_by_type
+
+//
+//Decipher colours and function of wires into a text string
+//
+
+/datum/wires/proc/SolveWires()
+	var/list/unsolved_wires = wires.Copy()
+	var/colour_function
+	var/solved_colour_function
+
+	var/name_by_type = name_by_type()
+
+	var/solved_txt = "[name_by_type] wires:<br>"
+
+	for(var/colour in wireColours) //Eg: Red
+		if(unsolved_wires[colour]) //unsolved_wires[red]
+			colour_function = unsolved_wires[colour] //unsolved_wires[red] = 1 so colour_index = 1
+			solved_colour_function = SolveWireFunction(colour_function) //unsolved_wires[red] = 1, 1 = AIRLOCK_WIRE_IDSCAN
+			solved_txt += "the [colour] wire is the [solved_colour_function]<br>" //the red wire is the ID wire
+
+	solved_txt += "<br>"
+
+	return solved_txt
+
+

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -37,9 +37,10 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
+
+		H.mind.store_memory(all_solved_wires[/obj/machinery/door/airlock])
+		H.mind.store_memory(all_solved_wires[/obj/machinery/power/apc])
 		return 1
-
-
 
 /datum/job/engineer
 	title = "Station Engineer"
@@ -70,6 +71,8 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
+		H.mind.store_memory(all_solved_wires[/obj/machinery/door/airlock])
+		H.mind.store_memory(all_solved_wires[/obj/machinery/power/apc])
 		return 1
 
 
@@ -102,4 +105,6 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
+		H.mind.store_memory(all_solved_wires[/obj/machinery/door/airlock])
+		H.mind.store_memory(all_solved_wires[/obj/machinery/power/apc])
 		return 1

--- a/code/game/objects/items/weapons/implants/implantknowledge.dm
+++ b/code/game/objects/items/weapons/implants/implantknowledge.dm
@@ -1,0 +1,21 @@
+
+/obj/item/weapon/implant/wire_knowledge/implanted(mob/M)
+	if(!M.mind)
+		return 0
+	M.mind.store_memory("If you're reading this, Blame the nearest online Admin")
+	return 1
+
+/obj/item/weapon/implant/wire_knowledge/door/implanted(mob/M)
+	if(!M.mind)
+		return 0
+	M.mind.store_memory(all_solved_wires[/obj/machinery/door/airlock])
+	return 1
+
+/obj/item/weapon/implant/wire_knowledge
+	name = "Wire Knowledge: Blank"
+	desc = "This doesn't do ANYTHING"
+
+
+/obj/item/weapon/implant/wire_knowledge/door
+	name = "Wire Knowledge: Doors"
+	desc = "Grants you knowledge of the NT Door and Airlock wiring systems"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -98,6 +98,17 @@
 	O.update_icon()
 	return
 
+/obj/item/weapon/storage/box/syndie_kit/imp_wire_door
+	name = "boxed door wire knowledge implant (with injector)"
+
+/obj/item/weapon/storage/box/syndie_kit/imp_wire_door/New()
+	..()
+	var/obj/item/weapon/implanter/O = new(src)
+	O.imp = new /obj/item/weapon/implant/wire_knowledge/door(O)
+	O.update_icon()
+	return
+
+
 /*/obj/item/weapon/storage/box/syndie_kit/imp_compress
 	name = "Compressed Matter Implant (with injector)"
 
@@ -160,3 +171,5 @@
 	new /obj/item/weapon/implanter/emp/(src)
 	new /obj/item/device/flashlight/emp/(src)
 	return
+
+


### PR DESCRIPTION
At Roundstart an Engineer (CE, Engi or Atmos)'s Notes are filled with the Wires of APCs and Doors.
Adds an Implant to Syndicate Uplinks to grant them knowledge of Door wires (1 TC cheaper than an Emag because it requires the user to obtain tools)

Codewise:
Adds 3 procs.
- Get's the name of the object by it's wire datum
- Deciphers the Randomised Wire list
- Translate the Deciphered Bitflags into readable english

The SolveWires() proc outputs a string (Text) to an associative list based on the Wire datum passed to the SolveWires() Proc, This text string is valid where all others are, such as Memory procs.

Eg; all_solved_wires[/obj/machinery/door/airlock] contains the translated string from SolveWires()
