### PR TITLE
Removes Every Colon operator from Gamemode code. ALL OF THEM.

### DIFF
--- a/NTstation13.dme
+++ b/NTstation13.dme
@@ -234,6 +234,7 @@
 #include "code\game\gamemodes\events.dm"
 #include "code\game\gamemodes\factions.dm"
 #include "code\game\gamemodes\game_mode.dm"
+#include "code\game\gamemodes\gamemode_helpers.dm"
 #include "code\game\gamemodes\gameticker.dm"
 #include "code\game\gamemodes\intercept_report.dm"
 #include "code\game\gamemodes\objective.dm"

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -69,19 +69,22 @@
 				continue
 
 			if(istype(T,/turf/simulated/floor))
-				if(!(T:burnt))
+				var/turf/simulated/floor/F = T
+				if(!(F.burnt))
 					src.floor += 12
 				else
 					src.floor += 1
 
 			if(istype(T, /turf/simulated/wall))
-				if(T:intact)
+				var/turf/simulated/wall/W = T
+				if(W.intact)
 					src.wall += 2
 				else
 					src.wall += 1
 
 			if(istype(T, /turf/simulated/wall/r_wall))
-				if(T:intact)
+				var/turf/simulated/wall/r_wall/R = T
+				if(R.intact)
 					src.r_wall += 2
 				else
 					src.r_wall += 1
@@ -92,8 +95,10 @@
 
 			if(istype(O, /obj/structure/window))
 				src.window += 1
-			else if(istype(O, /obj/structure/grille) && (!O:destroyed))
-				src.grille += 1
+			else if(istype(O, /obj/structure/grille))
+				var/obj/structure/grille/G = O
+				if(!G.destroyed)
+					src.grille += 1
 			else if(istype(O, /obj/machinery/door))
 				src.door += 1
 			else if(istype(O, /obj/machinery))

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -15,7 +15,7 @@
 	if(istype(mind.current, /mob/living/carbon/human) && (mind.assigned_role in list("Captain", "Chaplain")))	return 0
 	if(isloyal(mind.current))
 		return 0
-	if (ticker.mode.name == "cult")		//redundent?
+	if(game_is_cult_mode(ticker.mode))
 		if(mind.current == ticker.mode.sacrifice_target)	return 0
 	return 1
 
@@ -102,8 +102,6 @@
 
 	for(var/datum/mind/cult_mind in cult)
 		equip_cultist(cult_mind.current)
-//		grant_runeword(cult_mind.current)
-//		grant_secondword(cult_mind.current)
 		update_cult_icons_added(cult_mind)
 		cult_mind.current << "\blue You are a member of the cult!"
 		memorize_cult_objectives(cult_mind)
@@ -133,8 +131,6 @@
 	cult_mind.memory += "The Geometer of Blood grants you the knowledge to sacrifice non-believers. (Hell Blood Join)<BR>"
 	for(var/startingword in startwords)
 		grant_runeword(cult_mind.current,startingword)
-//	grant_runeword(cult_mind.current,"blood")
-//	grant_runeword(cult_mind.current,"hell")
 
 /datum/game_mode/proc/equip_cultist(mob/living/carbon/human/mob)
 	if(!istype(mob))
@@ -162,21 +158,6 @@
 		mob.update_icons()
 		return 1
 
-
-//datum/game_mode/cult/proc/grant_secondword(mob/living/carbon/human/cult_mob, var/word)
-//	if (!word)
-//		if(secondwords.len > 0)
-//			word=pick(secondwords)
-//			secondwords -= word
-//			grant_runeword(cult_mob,word)
-
-//datum/game_mode/cult/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
-//	if (!word)
-//		if(startwords.len > 0)
-//			word=pick(startwords)
-//			startwords -= word
-//	return ..(cult_mob,word)
-
 /datum/game_mode/proc/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
 	if(!wordtravel)
 		runerandom()
@@ -202,10 +183,6 @@
 			wordexp = "[worddestr] is destroy..."
 		if("other")
 			wordexp = "[wordother] is other..."
-//		if("hear")
-//			wordexp = "[wordhear] is hear..."
-//		if("free")
-//			wordexp = "[wordfree] is free..."
 		if("hide")
 			wordexp = "[wordhide] is hide..."
 	cult_mob << "\red [pick("You remember something from the dark teachings of your master","You hear a dark voice on the wind","Black blood oozes into your vision and forms into symbols","You catch a brief glimmer of the otherside")]... [wordexp]"

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -24,17 +24,6 @@
 	name = "Desk"
 	desc = "A desk covered in arcane manuscripts and tomes in unknown languages. Looking at the text makes your skin crawl"
 	icon_state = "tomealtar"
-//	luminosity = 5
-
-//sprites for this no longer exist	-Pete
-//(they were stolen from another game anyway)
-/*
-/obj/structure/cult/pillar
-	name = "Pillar"
-	desc = "This should not exist"
-	icon_state = "pillar"
-	icon = 'magic_pillar.dmi'
-*/
 
 /obj/effect/gateway
 	name = "gateway"

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -10,8 +10,6 @@ var/wordjoin = null
 var/wordtech = null
 var/worddestr = null
 var/wordother = null
-//var/wordhear = null
-//var/wordfree = null
 var/wordhide = null
 var/runedec = 0
 var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
@@ -90,10 +88,6 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 	runewords-=worddestr
 	wordother=pick(runewords)
 	runewords-=wordother
-//	wordhear=pick(runewords)
-//	runewords-=wordhear
-//	wordfree=pick(runewords)
-//	runewords-=wordfree
 	wordhide=pick(runewords)
 	runewords-=wordhide
 
@@ -152,13 +146,6 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 		if(!iscultist(usr))
 			usr << "A strange collection of symbols drawn in blood."
 			return
-			/* Explosions... really?
-			if(desc && !usr.stat)
-				usr << "It reads: <i>[desc]</i>."
-				sleep(30)
-				explosion(src.loc, 0, 2, 5, 5)
-				qdel(src)
-			*/
 		if(!desc)
 			usr << "A spell circle drawn in blood. It reads: <i>[word1] [word2] [word3]</i>."
 		else
@@ -488,29 +475,9 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 						[words[10]] is <a href='byond://?src=\ref[src];number=10;action=change'>[words[words[10]]]</A> <A href='byond://?src=\ref[src];number=10;action=clear'>Clear</A><BR>
 						"}
 			usr << browse("[notedat]", "window=notes")
-//		call(/obj/item/weapon/tome/proc/edit_notes)()
 		else
 			usr << browse(null, "window=notes")
 			return
-
-
-//	proc/edit_notes()     FUCK IT. Cant get it to work properly. - K0000
-//		world << "its been called! [usr]"
-//		notedat = {"
-//		<br><b>Word translation notes</b> <br>
-//			[words[1]] is <a href='byond://?src=\ref[src];number=1;action=change'>[words[words[1]]]</A> <A href='byond://?src=\ref[src];number=1;action=clear'>Clear</A><BR>
-//			[words[2]] is <A href='byond://?src=\ref[src];number=2;action=change'>[words[words[2]]]</A> <A href='byond://?src=\ref[src];number=2;action=clear'>Clear</A><BR>
-//			[words[3]] is <a href='byond://?src=\ref[src];number=3;action=change'>[words[words[3]]]</A> <A href='byond://?src=\ref[src];number=3;action=clear'>Clear</A><BR>
-//			[words[4]] is <a href='byond://?src=\ref[src];number=4;action=change'>[words[words[4]]]</A> <A href='byond://?src=\ref[src];number=4;action=clear'>Clear</A><BR>
-//			[words[5]] is <a href='byond://?src=\ref[src];number=5;action=change'>[words[words[5]]]</A> <A href='byond://?src=\ref[src];number=5;action=clear'>Clear</A><BR>
-//			[words[6]] is <a href='byond://?src=\ref[src];number=6;action=change'>[words[words[6]]]</A> <A href='byond://?src=\ref[src];number=6;action=clear'>Clear</A><BR>
-//			[words[7]] is <a href='byond://?src=\ref[src];number=7;action=change'>[words[words[7]]]</A> <A href='byond://?src=\ref[src];number=7;action=clear'>Clear</A><BR>
-//			[words[8]] is <a href='byond://?src=\ref[src];number=8;action=change'>[words[words[8]]]</A> <A href='byond://?src=\ref[src];number=8;action=clear'>Clear</A><BR>
-//			[words[9]] is <a href='byond://?src=\ref[src];number=9;action=change'>[words[words[9]]]</A> <A href='byond://?src=\ref[src];number=9;action=clear'>Clear</A><BR>
-//			[words[10]] is <a href='byond://?src=\ref[src];number=10;action=change'>[words[words[10]]]</A> <A href='byond://?src=\ref[src];number=10;action=clear'>Clear</A><BR>
-//					"}
-//		usr << "whatev"
-//		usr << browse(null, "window=tank")
 
 	attack(mob/living/M as mob, mob/living/user as mob)
 		add_logs(user, M, "smacked", object=src)
@@ -554,8 +521,6 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				return
 
 
-
-
 			if (C>=26+runedec+ticker.mode.cult.len) //including the useless rune at the secret room, shouldn't count against the limit of 25 runes - Urist
 				alert("The cloth of reality can't take that much of a strain. Remove some runes first!")
 				return
@@ -592,7 +557,6 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 							[words[9]] is <a href='byond://?src=\ref[src];number=9;action=change'>[words[words[9]]]</A> <A href='byond://?src=\ref[src];number=9;action=clear'>Clear</A><BR>
 							[words[10]] is <a href='byond://?src=\ref[src];number=10;action=change'>[words[words[10]]]</A> <A href='byond://?src=\ref[src];number=10;action=clear'>Clear</A><BR>
 							"}	// whoever screwed the tabbing on this originally is an asshole.
-//						call(/obj/item/weapon/tome/proc/edit_notes)()
 						user << browse("[notedat]", "window=notes")
 						return
 					if("Scribe a rune")		//fixed more assbackward tabbing
@@ -686,11 +650,6 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			switch(alert("Copy the runes from your tome?",,"Copy", "Cancel"))
 				if("cancel")
 					return
-	//		var/list/nearby = viewers(1,src) //- Fuck this as well. No clue why this doesnt work. -K0000
-	//			if (T.loc != user)
-	//				return
-	//		for(var/mob/M in nearby)
-	//			if(M == user)
 			for(var/entry in words)
 				words[entry] = T.words[entry]
 			user << "You copy the translation notes from your tome."

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -8,7 +8,6 @@ var/list/sacrificed = list()
 			var/allrunesloc[]
 			allrunesloc = new/list()
 			var/index = 0
-		//	var/tempnum = 0
 			for(var/obj/effect/rune/R in world)
 				if(R == src)
 					continue
@@ -39,10 +38,6 @@ var/list/sacrificed = list()
 
 
 		itemport(var/key)
-//			var/allrunesloc[]
-//			allrunesloc = new/list()
-//			var/index = 0
-		//	var/tempnum = 0
 			var/culcount = 0
 			var/runecount = 0
 			var/obj/effect/rune/IP = null
@@ -118,26 +113,10 @@ var/list/sacrificed = list()
 						M.mind.special_role = "Cultist"
 						M << "<font color=\"purple\"><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</b></i></font>"
 						M << "<font color=\"purple\"><b><i>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve the Dark One above all else. Bring It back.</b></i></font>"
-	/*	//convert no longer gives words
-						//picking which word to use
-						if(usr.mind.cult_words.len != ticker.mode.allwords.len) // No point running if they already know everything
-							var/convert_word
-							for(var/i=1, i<=3, i++)
-								convert_word = pick(ticker.mode.grantwords)
-								if(convert_word in usr.mind.cult_words)
-									if(i==3) convert_word = null				//NOTE: If max loops is changed ensure this condition is changed to match /Mal
-								else
-									break
-							if(!convert_word)
-								usr << "\red This Convert was unworthy of knowledge of the other side!"
-							else
-								usr << "\red The Geometer of Blood is pleased to see his followers grow in numbers."
-								ticker.mode.grant_runeword(usr, convert_word)
-							return 1		*/
 					else
 						M << "<font color=\"purple\"><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</b></i></font>"
 						M << "<font color=\"red\"><b>And not a single fuck was given, exterminate the cult at all costs.</b></font>"
-						if(ticker.mode.name == "cult")
+						if(game_is_cult_mode(ticker.mode))
 							if(M.mind == ticker.mode.sacrifice_target)
 								for(var/mob/living/carbon/human/cultist in cultsinrange)
 									cultist << "<span class='h2.userdanger'>The Chosen One!! <BR>KILL THE CHOSEN ONE!!! </span>"
@@ -158,9 +137,10 @@ var/list/sacrificed = list()
 					M.say("Tok-lyr rqa'nap g[pick("'","`")]lt-ulotf!")
 					cultist_count += M
 			if(cultist_count.len >= 9)
-				if(ticker.mode.name == "cult")
-					if("eldergod" in ticker.mode.cult_objectives)
-						ticker.mode:eldergod = 0
+				if(game_is_cult_mode(ticker.mode))
+					var/datum/game_mode/cult/Cult = ticker.mode
+					if("eldergod" in Cult.cult_objectives)
+						Cult.eldergod = 0
 					else
 						message_admins("[usr.real_name]([usr.ckey]) tried to summon a god when she didn't want to come out to play.")	// Admin alert because you *KNOW* dickbutts are going to abuse this.
 						for(var/mob/M in cultist_count)
@@ -269,8 +249,10 @@ var/list/sacrificed = list()
 			var/is_sacrifice_target = 0
 			for(var/mob/living/carbon/human/M in src.loc)
 				if(M.stat == DEAD)
-					if(ticker.mode.name == "cult" && M.mind == ticker.mode:sacrifice_target)
-						is_sacrifice_target = 1
+					if(game_is_cult_mode(ticker.mode))
+						var/datum/game_mode/cult/Cult = ticker.mode
+						if(M.mind == Cult.sacrifice_target)
+							is_sacrifice_target = 1
 					else
 						corpse_to_raise = M
 						if(M.key)
@@ -287,8 +269,10 @@ var/list/sacrificed = list()
 				for(var/obj/effect/rune/R in world)
 					if(R.word1==wordblood && R.word2==wordjoin && R.word3==wordhell)
 						for(var/mob/living/carbon/human/N in R.loc)
-							if(ticker.mode.name == "cult" && N.mind && N.mind == ticker.mode:sacrifice_target)
-								is_sacrifice_target = 1
+							if(game_is_cult_mode(ticker.mode))
+								var/datum/game_mode/cult/Cult = ticker.mode
+								if(N.mind && N.mind == Cult.sacrifice_target)
+									is_sacrifice_target = 1
 							else
 								if(N.stat!= DEAD)
 									body_to_sacrifice = N
@@ -320,10 +304,6 @@ var/list/sacrificed = list()
 			corpse_to_raise.SetStunned(0)
 			corpse_to_raise.SetWeakened(0)
 			corpse_to_raise.radiation = 0
-//			corpse_to_raise.buckled = null
-//			if(corpse_to_raise.handcuffed)
-//				qdel(corpse_to_raise.handcuffed)
-//				corpse_to_raise.update_inv_handcuffed(0)
 			corpse_to_raise.stat = CONSCIOUS
 			corpse_to_raise.updatehealth()
 			corpse_to_raise.update_damage_overlays(0)
@@ -338,11 +318,6 @@ var/list/sacrificed = list()
 			"\red You feel as your blood boils, tearing you apart.", \
 			"\red You hear a thousand voices, all crying in pain.")
 			body_to_sacrifice.gib()
-
-//			if(ticker.mode.name == "cult")
-//				ticker.mode:add_cultist(corpse_to_raise.mind)
-//			else
-//				ticker.mode.cult |= corpse_to_raise.mind
 
 			corpse_to_raise << "<font color=\"purple\"><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</b></i></font>"
 			corpse_to_raise << "<font color=\"purple\"><b><i>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve the Dark One above all else. Bring It back.</b></i></font>"
@@ -430,8 +405,9 @@ var/list/sacrificed = list()
 
 			D.key = ghost.key
 
-			if(ticker.mode.name == "cult")
-				ticker.mode:add_cultist(D.mind)
+			if(game_is_cult_mode(ticker.mode))
+				var/datum/game_mode/cult/Cult = ticker.mode
+				Cult.add_cultist(D.mind)
 			else
 				ticker.mode.cult+=D.mind
 
@@ -605,8 +581,9 @@ var/list/sacrificed = list()
 					C.say("Barhah hra zar[pick("'","`")]garis!")
 					if(cultsinrange.len >= 3) break		//we only need to check for three alive cultists, loop breaks so their aren't extra cultists getting word rewards
 			for(var/mob/H in victims)
-				if (ticker.mode.name == "cult")
-					if(H.mind == ticker.mode:sacrifice_target)
+				if (game_is_cult_mode(ticker.mode))
+					var/datum/game_mode/cult/Cult = ticker.mode
+					if(H.mind == Cult.sacrifice_target)
 						if(cultsinrange.len >= 3)
 							sacrificed += H.mind
 							stone_or_gib(H)
@@ -671,8 +648,9 @@ var/list/sacrificed = list()
 								usr << "\red However, a mere dead body is not enough to satisfy Him."
 							stone_or_gib(H)
 			for(var/mob/living/carbon/monkey/M in src.loc)
-				if (ticker.mode.name == "cult")
-					if(M.mind == ticker.mode:sacrifice_target)
+				if (game_is_cult_mode(ticker.mode))
+					var/datum/game_mode/cult/Cult = ticker.mode
+					if(M.mind == Cult.sacrifice_target)
 						if(cultsinrange.len >= 3)
 							sacrificed += M.mind
 							for(var/mob/living/carbon/C in cultsinrange)
@@ -698,21 +676,6 @@ var/list/sacrificed = list()
 				stone_or_gib(M)
 			for(var/mob/victim in src.loc)			//TO-DO: Move the shite above into the mob's own sac_act - see /mob/living/simple_animal/corgi/sac_act for an example
 				victim.sac_act(src, victim)			//Sacrifice procs are now seperate per mob, this allows us to allow sacrifice on as many mob types as we want without making an already clunky system worse
-/*			for(var/mob/living/carbon/alien/A)
-				for(var/mob/K in cultsinrange)
-					K.say("Barhah hra zar'garis!")
-				A.dust()      /// A.gib() doesnt work for some reason, and dust() leaves that skull and bones thingy which we dont really need.
-				if (ticker.mode.name == "cult")
-					if(prob(75))
-						usr << "\red The Geometer of Blood accepts your exotic sacrifice."
-						sac_grant_word()
-					else
-						usr << "\red The Geometer of Blood accepts your exotic sacrifice."
-						usr << "\red However, this alien is not enough to gain His favor."
-				else
-					usr << "\red The Geometer of Blood accepts your exotic sacrifice."
-				return
-			return fizzle() */
 
 		sac_grant_word(var/mob/living/C)	//The proc that which chooses a word rewarded for a successful sacrifice, sacrifices always give a currently unknown word if the normal checks pass
 			if(C.mind.cult_words.len != ticker.mode.allwords.len) // No point running if they already know everything
@@ -807,15 +770,32 @@ var/list/sacrificed = list()
 					return fizzle()
 				if (cultist == user) //just to be sure.
 					return
-				if(!(cultist.buckled || \
-					cultist.handcuffed || \
-					istype(cultist.wear_mask, /obj/item/clothing/mask/muzzle) || \
-					(istype(cultist.loc, /obj/structure/closet)&&cultist.loc:welded) || \
-					(istype(cultist.loc, /obj/structure/closet/secure_closet)&&cultist.loc:locked) || \
-					(istype(cultist.loc, /obj/machinery/dna_scannernew)&&cultist.loc:locked) \
-				))
-					user << "\red The [cultist] is already free."
+
+				var/is_free = 0
+
+				if(!cultist.buckled)
+					is_free++
+				if(!cultist.handcuffed)
+					is_free++
+				if(!istype(cultist.wear_mask, /obj/item/clothing/mask/muzzle))
+					is_free++
+				if(istype(cultist.loc, /obj/structure/closet))
+					var/obj/structure/closet/cultist_loc = cultist.loc
+					if(!cultist_loc.welded)
+						is_free++
+				if(istype(cultist.loc, /obj/structure/closet/secure_closet))
+					var/obj/structure/closet/secure_closet/cultist_loc = cultist.loc
+					if(!cultist_loc.locked)
+						is_free++
+				if(istype(cultist.loc, /obj/machinery/dna_scannernew))
+					var/obj/machinery/dna_scannernew/cultist_loc = cultist.loc
+					if(!cultist_loc.locked)
+						is_free++
+
+				if(is_free)
+					user << "<span class='warning'>The [cultist] is already free.</span>"
 					return
+
 				cultist.buckled = null
 				if (cultist.handcuffed)
 					cultist.handcuffed.loc = cultist.loc
@@ -827,12 +807,18 @@ var/list/sacrificed = list()
 					cultist.update_inv_legcuffed(0)
 				if (istype(cultist.wear_mask, /obj/item/clothing/mask/muzzle))
 					cultist.unEquip(cultist.wear_mask)
-				if(istype(cultist.loc, /obj/structure/closet)&&cultist.loc:welded)
-					cultist.loc:welded = 0
-				if(istype(cultist.loc, /obj/structure/closet/secure_closet)&&cultist.loc:locked)
-					cultist.loc:locked = 0
-				if(istype(cultist.loc, /obj/machinery/dna_scannernew)&&cultist.loc:locked)
-					cultist.loc:locked = 0
+				if(istype(cultist.loc, /obj/structure/closet))
+					var/obj/structure/closet/cultist_loc = cultist.loc
+					if(cultist_loc.welded)
+						cultist_loc.welded = 0
+				if(istype(cultist.loc, /obj/structure/closet/secure_closet))
+					var/obj/structure/closet/secure_closet/cultist_loc = cultist.loc
+					if(cultist_loc.locked)
+						cultist_loc.locked = 0
+				if(istype(cultist.loc, /obj/machinery/dna_scannernew))
+					var/obj/machinery/dna_scannernew/cultist_loc = cultist.loc
+					if(cultist_loc.locked)
+						cultist_loc.locked = 0
 				for(var/mob/living/carbon/C in users)
 					user.take_overall_damage(15, 0)
 					C.say("Khari[pick("'","`")]d! Gual'te nikka!")
@@ -1090,7 +1076,6 @@ var/list/sacrificed = list()
 				if(PS.amount >= 4)		// may need increasing?
 					usr.say("Eth ra p'ni[pick("'","`")]dedo ol!")		//I have no idea if these are written in a proper made up language or just Urist smacking his face on the keyboard
 					new /obj/structure/constructshell(src.loc)
-		//?			PS.remove_amount(4)			//TO-DO: Write a proc for removing sheets from a stack and deleting when stack is empty... why doesnt this exist yet??
 					PS.amount -= 4
 					if(PS.amount <= 0)
 						qdel(PS)

--- a/code/game/gamemodes/gamemode_helpers.dm
+++ b/code/game/gamemodes/gamemode_helpers.dm
@@ -1,0 +1,64 @@
+
+/*
+procs designed to work out the current gamemode.
+Added to remove MOST (All hopefully) colons in Gamemode code by
+making typecasting of the gamemode easier - RemieRichards
+*/
+
+
+proc/game_is_malf_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/malfunction))
+		return 1
+	return 0
+
+proc/game_is_cult_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/cult))
+		return 1
+	return 0
+
+proc/game_is_extended_mode(var/ticker_mode) //if you need this... what are you doing?
+	if(istype(ticker_mode,/datum/game_mode/extended))
+		return 1
+	return 0
+
+proc/game_is_meteor_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/meteor))
+		return 1
+	return 0
+
+proc/game_is_blob_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/blob))
+		return 1
+	return 0
+
+proc/game_is_nuclear_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/nuclear))
+		return 1
+	return 0
+
+proc/game_is_rev_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/revolution))
+		return 1
+	return 0
+
+proc/game_is_sandbox_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/sandbox))
+		return 1
+	return 0
+
+proc/game_is_traitor_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/traitor))
+		return 1
+	return 0
+
+proc/game_is_doubleagents_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/traitor/double_agents))
+		return 1
+	return 0
+
+proc/game_is_wizard_mode(var/ticker_mode)
+	if(istype(ticker_mode,/datum/game_mode/wizard))
+		return 1
+	return 0
+
+

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -223,8 +223,11 @@
 	set category = "Malfunction"
 	set name = "Hack intercept"
 	src.verbs -= /mob/living/silicon/ai/proc/interhack
-	ticker.mode:hack_intercept()
-	src << "<span class='notice'>Status update intercepted and modified.</span>"
+
+	if(game_is_malf_mode(ticker.mode))
+		var/datum/game_mode/malfunction/Malf = ticker.mode
+		Malf.hack_intercept()
+		src << "<span class='notice'>Status update intercepted and modified.</span>"
 
 /datum/AI_Module/small/reactivate_camera
 	module_name = "Reactivate camera"

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -17,7 +17,6 @@
 
 
 /datum/game_mode/meteor/post_setup()
-//	defer_powernet_rebuild = 2//Might help with the lag
 	spawn (rand(waittime_l, waittime_h))
 		send_intercept()
 	spawn(meteordelay)
@@ -27,12 +26,6 @@
 
 /datum/game_mode/meteor/process()
 	if(nometeors) return
-	/*if(prob(80))
-		spawn()
-			dust_swarm("norm")
-	else
-		spawn()
-			dust_swarm("strong")*/
 	spawn() spawn_meteors(6)
 
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -245,13 +245,6 @@
 			disk_rescued = 0
 			break
 	var/crew_evacuated = (emergency_shuttle.location==2)
-	//var/operatives_are_dead = is_operatives_are_dead()
-
-
-	//nukes_left
-	//station_was_nuked
-	//derp //Used for tracking if the syndies actually haul the nuke to the station	//no
-	//herp //Used for tracking if the syndies got the shuttle off of the z-level	//NO, DON'T FUCKING NAME VARS LIKE THIS
 
 	if      (!disk_rescued &&  station_was_nuked &&          !syndies_didnt_escape)
 		feedback_set_details("round_end_result","win - syndicate nuke")

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -180,23 +180,25 @@ var/bomb_set
 		off_station = 2
 
 	if(ticker)
-		if(ticker.mode && ticker.mode.name == "nuclear emergency")
+		if(ticker.mode && game_is_nuclear_mode(ticker.mode))
+			var/datum/game_mode/nuclear/Nuke = ticker.mode
 			var/obj/machinery/computer/syndicate_station/syndie_location = locate(/obj/machinery/computer/syndicate_station)
 			if(syndie_location)
-				ticker.mode:syndies_didnt_escape = (syndie_location.z > 1 ? 0 : 1)	//muskets will make me change this, but it will do for now
-			ticker.mode:nuke_off_station = off_station
+				Nuke.syndies_didnt_escape = (syndie_location.z > 1 ? 0 : 1)	//muskets will make me change this, but it will do for now
+			Nuke.nuke_off_station = off_station
 		ticker.station_explosion_cinematic(off_station,null)
-		if(ticker.mode)
+		if(ticker.mode && game_is_nuclear_mode(ticker.mode))
+			var/datum/game_mode/nuclear/Nuke = ticker.mode
 			ticker.mode.explosion_in_progress = 0
-			if(ticker.mode.name == "nuclear emergency")
-				ticker.mode:nukes_left --
+			if(Nuke.name == "nuclear emergency")
+				Nuke.nukes_left --
 			else
 				world << "<B>The station was destoyed by the nuclear blast!</B>"
 
-			ticker.mode.station_was_nuked = (off_station<2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
+			Nuke.station_was_nuked = (off_station<2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
 															//kinda shit but I couldn't  get permission to do what I wanted to do.
 
-			if(!ticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
+			if(!Nuke.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
 				world << "<B>Resetting in 30 seconds!</B>"
 
 				feedback_set_details("end_error","nuke - unhandled ending")

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -186,9 +186,6 @@
 		if(!the_disk)
 			icon_state = "pinonnull"
 			return
-//	if(loc.z != the_disk.z)	//If you are on a different z-level from the disk
-//		icon_state = "pinonnull"
-//	else
 	dir = get_dir(src, the_disk)
 	switch(get_dist(src, the_disk))
 		if(0)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -1,11 +1,12 @@
-// To add a rev to the list of revolutionaries, make sure it's rev (with if(ticker.mode.name == "revolution)),
-// then call ticker.mode:add_revolutionary(_THE_PLAYERS_MIND_)
+// To add a rev to the list of revolutionaries, make sure it's rev (with if(game_is_rev_mode(ticker.mode)),
+// then typecast the game mode to rev: var/datum/game_mode/revolution/Rev = ticker.mode
+// then call Rev.add_revolutionary(_THE_PLAYERS_MIND_)
 // nothing else needs to be done, as that proc will check if they are a valid target.
 // Just make sure the converter is a head before you call it!
-// To remove a rev (from brainwashing or w/e), call ticker.mode:remove_revolutionary(_THE_PLAYERS_MIND_),
+// To remove a rev (from brainwashing or w/e), call Rev.remove_revolutionary(_THE_PLAYERS_MIND_),
 // this will also check they're not a head, so it can just be called freely
 // If the rev icons start going wrong for some reason, ticker.mode:update_all_rev_icons() can be called to correct them.
-// If the game somtimes isn't registering a win properly, then ticker.mode.check_win() isn't being called somewhere.
+// If the game somtimes isn't registering a win properly, then Rev.check_win() isn't being called somewhere.
 
 /datum/game_mode
 	var/list/datum/mind/head_revolutionaries = list()
@@ -354,7 +355,7 @@
 /datum/game_mode/proc/auto_declare_completion_revolution()
 	var/list/targets = list()
 
-	if(head_revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution))
+	if(head_revolutionaries.len || game_is_rev_mode(ticker.mode))
 		var/text = "<br><font size=3><b>The head revolutionaries were:</b></font>"
 
 		for(var/datum/mind/headrev in head_revolutionaries)
@@ -378,7 +379,7 @@
 
 		world << text
 
-	if(revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution))
+	if(revolutionaries.len || game_is_rev_mode(ticker.mode))
 		var/text = "<br><font size=3><b>The revolutionaries were:</b></font>"
 
 		for(var/datum/mind/rev in revolutionaries)
@@ -400,7 +401,7 @@
 		world << text
 
 
-	if( head_revolutionaries.len || revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution) )
+	if( head_revolutionaries.len || revolutionaries.len || game_is_rev_mode(ticker.mode) )
 		var/text = "<br><font size=3><b>The heads of staff were:</b></font>"
 
 		var/list/heads = get_all_heads()

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -22,13 +22,6 @@
 		transfer_soul("VICTIM", M, user)
 		return
 
-	/*attack(mob/living/simple_animal/shade/M as mob, mob/user as mob)//APPARENTLY THEY NEED THEIR OWN SPECIAL SNOWFLAKE CODE IN THE LIVING ANIMAL DEFINES
-		if(!istype(M, /mob/living/simple_animal/shade))//If target is not a shade
-			return ..()
-		user.attack_log += text("\[[time_stamp()]\] <span class='danger'>Used the [src.name] to capture the soul of [M.name] ([M.ckey])</span>")
-
-		transfer_soul("SHADE", M, user)
-		return*/
 ///////////////////Options for using captured souls///////////////////////////////////////
 
 	attack_self(mob/user)
@@ -44,9 +37,6 @@
 		user << browse(dat, "window=aicard")
 		onclose(user, "aicard")
 		return
-
-
-
 
 	Topic(href, href_list)
 		var/mob/U = usr
@@ -109,12 +99,14 @@
 		if("VICTIM")
 			var/mob/living/carbon/human/T = target
 			var/obj/item/device/soulstone/C = src
-			if(ticker.mode.name == "cult" && T.mind == ticker.mode:sacrifice_target)
-				if(iscultist(U))
-					U << "<span class='danger'>The Geometer of blood wants this mortal sacrificed with the rune.</span>"
-				else
-					U << "<span class='danger'>The soul stone doesn't work for no apparent reason.</span>"
-				return 0
+			if(game_is_cult_mode(ticker.mode))
+				var/datum/game_mode/cult/Cult = ticker.mode
+				if(T.mind == Cult.sacrifice_target)
+					if(iscultist(U))
+						U << "<span class='danger'>The Geometer of blood wants this mortal sacrificed with the rune.</span>"
+					else
+						U << "<span class='danger'>The soul stone doesn't work for no apparent reason.</span>"
+					return 0
 			if(C.imprinted != "empty")
 				U << "<span class='userdanger'>Capture failed!</span>: The soul stone has already been imprinted with [C.imprinted]'s mind!"
 			else
@@ -162,8 +154,9 @@
 						var/mob/living/simple_animal/construct/armoured/Z = new /mob/living/simple_animal/construct/armoured (get_turf(T.loc))
 						Z.key = A.key
 						if(iscultist(U))
-							if(ticker.mode.name == "cult")
-								ticker.mode:add_cultist(Z.mind)
+							if(game_is_cult_mode(ticker.mode))
+								var/datum/game_mode/cult/Cult = ticker.mode
+								Cult.add_cultist(Z.mind)
 							else
 								ticker.mode.cult+=Z.mind
 							ticker.mode.update_cult_icons_added(Z.mind)
@@ -177,8 +170,9 @@
 						var/mob/living/simple_animal/construct/wraith/Z = new /mob/living/simple_animal/construct/wraith (get_turf(T.loc))
 						Z.key = A.key
 						if(iscultist(U))
-							if(ticker.mode.name == "cult")
-								ticker.mode:add_cultist(Z.mind)
+							if(game_is_cult_mode(ticker.mode))
+								var/datum/game_mode/cult/Cult = ticker.mode
+								Cult.add_cultist(Z.mind)
 							else
 								ticker.mode.cult+=Z.mind
 							ticker.mode.update_cult_icons_added(Z.mind)
@@ -192,8 +186,9 @@
 						var/mob/living/simple_animal/construct/builder/Z = new /mob/living/simple_animal/construct/builder (get_turf(T.loc))
 						Z.key = A.key
 						if(iscultist(U))
-							if(ticker.mode.name == "cult")
-								ticker.mode:add_cultist(Z.mind)
+							if(game_is_cult_mode(ticker.mode))
+								var/datum/game_mode/cult/Cult = ticker.mode
+								Cult.add_cultist(Z.mind)
 							else
 								ticker.mode.cult+=Z.mind
 							ticker.mode.update_cult_icons_added(Z.mind)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -130,17 +130,6 @@
 		obj_count++
 	return
 
-
-/*/datum/game_mode/proc/learn_basic_spells(mob/living/carbon/human/wizard_mob)
-	if (!istype(wizard_mob))
-		return
-	if(!config.feature_object_spell_system)
-		wizard_mob.verbs += /client/proc/jaunt
-		wizard_mob.mind.special_verbs += /client/proc/jaunt
-	else
-		wizard_mob.spell_list += new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt(usr)
-*/
-
 /datum/game_mode/proc/equip_wizard(mob/living/carbon/human/wizard_mob)
 	if (!istype(wizard_mob))
 		return
@@ -161,7 +150,6 @@
 	if(wizard_mob.backbag == 2) wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(wizard_mob), slot_back)
 	if(wizard_mob.backbag == 3) wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(wizard_mob), slot_back)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(wizard_mob), slot_in_backpack)
-//	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/scrying_gem(wizard_mob), slot_l_store) For scrying gem.
 	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/teleportation_scroll(wizard_mob), slot_r_store)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/spellbook(wizard_mob), slot_r_hand)
 
@@ -272,15 +260,20 @@
 /*Checks if the wizard can cast spells.
 Made a proc so this is not repeated 14 (or more) times.*/
 /mob/proc/casting()
-//Removed the stat check because not all spells require clothing now.
-	if(!istype(usr:wear_suit, /obj/item/clothing/suit/wizrobe))
-		usr << "I don't feel strong enough without my robe."
-		return 0
-	if(!istype(usr:shoes, /obj/item/clothing/shoes/sandal))
-		usr << "I don't feel strong enough without my sandals."
-		return 0
-	if(!istype(usr:head, /obj/item/clothing/head/wizard))
-		usr << "I don't feel strong enough without my hat."
-		return 0
-	else
-		return 1
+//Removed the stat check because not all spells require clothing now
+
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+
+		if(!istype(H.wear_suit, /obj/item/clothing/suit/wizrobe))
+			usr << "I don't feel strong enough without my robe."
+			return 0
+		if(!istype(H.shoes, /obj/item/clothing/shoes/sandal))
+			usr << "I don't feel strong enough without my sandals."
+			return 0
+		if(!istype(H.head, /obj/item/clothing/head/wizard))
+			usr << "I don't feel strong enough without my hat."
+			return 0
+		else
+			return 1
+	return 0


### PR DESCRIPTION
- I have Removed every instance of Colon Operators in the Game mode code.
- I have added gamemode_helpers.dm containing "game_is_EXAMPLE_mode(var/ticker_mode)" procs
- I have removed _some_ ancient commented out code, it will never return so, Bye bye for good.

Bow before me code peasants. Nah but seriously guys don't use colons.

<b>For a Reviewer:</b>
For whomever wishes to review this, Considering the importance of the code that was changed here, I was extremely careful to maintain the original functionality of it all, but with nicer code (And no DAMN COLONS) so you'll need to trust me, or get a second opinion from another Coder.
