### PR TITLE
AI Sensor Augmentations! [Ready]

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -51,6 +51,10 @@ var/list/ai_list = list()
 	var/last_paper_seen = null
 	var/can_shunt = 1
 	var/last_announcement = "" // For AI VOX, if enabled
+	var/sensor_mode = 0 //Determines the AI's current HUD.
+	#define 	SEC_HUD 1 //Security HUD mode
+	#define 	MED_HUD 2 //Medical HUD mode
+	#define 	NIGHT 3   //Night vision mode
 
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
 	var/list/possibleNames = ai_names
@@ -92,7 +96,7 @@ var/list/ai_list = list()
 		verbs.Add(/mob/living/silicon/ai/proc/ai_call_shuttle,/mob/living/silicon/ai/proc/ai_camera_track, \
 		/mob/living/silicon/ai/proc/ai_camera_list, /mob/living/silicon/ai/proc/ai_network_change, \
 		/mob/living/silicon/ai/proc/ai_statuschange, /mob/living/silicon/ai/proc/ai_hologram_change, \
-		/mob/living/silicon/ai/proc/toggle_camera_light)
+		/mob/living/silicon/ai/proc/toggle_camera_light, /mob/living/silicon/ai/proc/sensor_mode)
 
 	if(!safety)//Only used by AIize() to successfully spawn an AI.
 		if (!B)//If there is no player/brain inside.
@@ -500,7 +504,6 @@ var/list/ai_list = list()
 		if(camera_light_on)	A.SetLuminosity(AI_CAMERA_LUMINOSITY)
 		else				A.SetLuminosity(0)
 
-
 /mob/living/silicon/ai/proc/switchCamera(var/obj/machinery/camera/C)
 
 	src.cameraFollow = null
@@ -516,6 +519,27 @@ var/list/ai_list = list()
 	//machine = src
 
 	return 1
+
+/mob/living/silicon/ai/proc/sensor_mode()
+	set category = "AI Commands"
+	set name = "Set Sensor Augmentation"
+	set desc = "Augment visual feed with internal sensor overlays."
+
+	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Light Amplification","Disable")
+	switch(sensor_type)
+		if ("Security")
+			src.sensor_mode = SEC_HUD
+			src << "<span class='notice'>Security records overlay enabled.</span>"
+
+		if ("Medical")
+			src.sensor_mode = MED_HUD
+			src << "<span class='notice'>Life signs monitor overlay enabled.</span>"
+		if ("Light Amplification")
+			src.sensor_mode = NIGHT
+			src << "<span class='notice'>Light amplification mode enabled.</span>"
+		if ("Disable")
+			src.sensor_mode = 0
+			src << "Sensor augmentations disabled."
 
 /mob/living/silicon/ai/triggerAlarm(var/class, area/A, var/O, var/alarmsource)
 	if (stat == 2)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -54,7 +54,7 @@ var/list/ai_list = list()
 	var/sensor_mode = 0 //Determines the AI's current HUD.
 	#define 	SEC_HUD 1 //Security HUD mode
 	#define 	MED_HUD 2 //Medical HUD mode
-	#define 	NIGHT 3   //Night vision mode
+//	#define 	NIGHT 3   //Night vision mode
 
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
 	var/list/possibleNames = ai_names
@@ -525,7 +525,7 @@ var/list/ai_list = list()
 	set name = "Set Sensor Augmentation"
 	set desc = "Augment visual feed with internal sensor overlays."
 
-	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Light Amplification","Disable")
+	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Disable")
 	switch(sensor_type)
 		if ("Security")
 			src.sensor_mode = SEC_HUD
@@ -534,9 +534,9 @@ var/list/ai_list = list()
 		if ("Medical")
 			src.sensor_mode = MED_HUD
 			src << "<span class='notice'>Life signs monitor overlay enabled.</span>"
-		if ("Light Amplification")
+/*		if ("Light Amplification")
 			src.sensor_mode = NIGHT
-			src << "<span class='notice'>Light amplification mode enabled.</span>"
+			src << "<span class='notice'>Light amplification mode enabled.</span>" */
 		if ("Disable")
 			src.sensor_mode = 0
 			src << "Sensor augmentations disabled."

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -54,7 +54,7 @@ var/list/ai_list = list()
 	var/sensor_mode = 0 //Determines the AI's current HUD.
 	#define 	SEC_HUD 1 //Security HUD mode
 	#define 	MED_HUD 2 //Medical HUD mode
-//	#define 	NIGHT 3   //Night vision mode
+	#define 	NIGHT 3   //Night vision mode
 
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
 	var/list/possibleNames = ai_names
@@ -525,7 +525,7 @@ var/list/ai_list = list()
 	set name = "Set Sensor Augmentation"
 	set desc = "Augment visual feed with internal sensor overlays."
 
-	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Disable")
+	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Light Amplification","Disable")
 	switch(sensor_type)
 		if ("Security")
 			src.sensor_mode = SEC_HUD
@@ -534,9 +534,9 @@ var/list/ai_list = list()
 		if ("Medical")
 			src.sensor_mode = MED_HUD
 			src << "<span class='notice'>Life signs monitor overlay enabled.</span>"
-/*		if ("Light Amplification")
+		if ("Light Amplification")
 			src.sensor_mode = NIGHT
-			src << "<span class='notice'>Light amplification mode enabled.</span>" */
+			src << "<span class='notice'>Light amplification mode enabled.</span>"
 		if ("Disable")
 			src.sensor_mode = 0
 			src << "Sensor augmentations disabled."

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -169,8 +169,8 @@
 			src.securityHUD(src.eyeobj)
 		if (MED_HUD)
 			src.medicalHUD(src.eyeobj)
-		if (NIGHT)
-			src.see_invisible = SEE_INVISIBLE_MINIMUM
+/*		if (NIGHT)
+			src.see_invisible = SEE_INVISIBLE_MINIMUM */
 
 /mob/living/silicon/ai/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -163,6 +163,15 @@
 							sleep(50)
 							theAPC = null
 
+	regular_hud_updates()
+	switch(src.sensor_mode)
+		if (SEC_HUD)
+			src.securityHUD(src.eyeobj)
+		if (MED_HUD)
+			src.medicalHUD(src.eyeobj)
+		if (NIGHT)
+			src.see_invisible = SEE_INVISIBLE_MINIMUM
+
 /mob/living/silicon/ai/updatehealth()
 	if(status_flags & GODMODE)
 		health = maxHealth

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -169,8 +169,8 @@
 			src.securityHUD(src.eyeobj)
 		if (MED_HUD)
 			src.medicalHUD(src.eyeobj)
-/*		if (NIGHT)
-			src.see_invisible = SEE_INVISIBLE_MINIMUM */
+		if (NIGHT)
+			src.see_invisible = SEE_INVISIBLE_MINIMUM
 
 /mob/living/silicon/ai/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/silicon/pai/hud.dm
+++ b/code/modules/mob/living/silicon/pai/hud.dm
@@ -1,14 +1,14 @@
-/mob/living/silicon/pai/proc/regular_hud_updates()
+/mob/living/silicon/proc/regular_hud_updates()
 	if(client)
 		for(var/image/hud in client.images)
 			if(copytext(hud.icon_state,1,4) == "hud")
 				client.images -= hud
 
-/mob/living/silicon/pai/proc/securityHUD()
+mob/living/silicon/proc/securityHUD(mob/living/silicon/S as mob)
 	if(client)
 		var/image/holder
-		var/turf/T = get_turf(src.loc)
-		for(var/mob/living/carbon/human/perp in view(T))
+		var/turf/T = get_turf(S)
+		for(var/mob/living/carbon/human/perp in range(T))
 			holder = perp.hud_list[ID_HUD]
 			holder.icon_state = "hudno_id"
 			if(perp.wear_id)
@@ -29,11 +29,11 @@
 							return
 					client.images += holder
 
-/mob/living/silicon/pai/proc/medicalHUD()
+/mob/living/silicon/proc/medicalHUD(mob/living/silicon/S as mob)
 	if(client)
 		var/image/holder
-		var/turf/T = get_turf(src.loc)
-		for(var/mob/living/carbon/human/patient in view(T))
+		var/turf/T = get_turf(S)
+		for(var/mob/living/carbon/human/patient in range(T))
 
 			var/foundVirus = 0
 			for(var/datum/disease/D in patient.viruses)
@@ -59,7 +59,7 @@
 				holder.icon_state = "hudhealthy"
 			client.images += holder
 
-/mob/living/silicon/pai/proc/RoundHealth(health)
+/mob/living/silicon/proc/RoundHealth(health)
 	switch(health)
 		if(100 to INFINITY)
 			return "health100"

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -11,9 +11,9 @@
 
 	regular_hud_updates()
 	if(src.secHUD == 1)
-		src.securityHUD()
+		src.securityHUD(src)
 	if(src.medHUD == 1)
-		src.medicalHUD()
+		src.medicalHUD(src)
 	if(silence_time)
 		if(world.timeofday >= silence_time)
 			silence_time = null


### PR DESCRIPTION
Discussion and poll here: http://tgstation13.org/phpBB/viewtopic.php?f=14&t=440
- Security Augmentation
  This function gives the AI the ability to identify the job and security status of any human crew member it sees. Unlike the cyborg or human versions, it strictly read-only. The AI is not able to set a human's security status this way, nor can it detect any implants. Its function is equal to that of the one used by pAI units.
- Life Signs Augmentation
  Perhaps the most useful of settings for Asimov AIs, this augmentation gives the AI a read-only medical HUD. Identical to the pAI function, it will provide data on wellness and infection status.
- Light Amplification Augmentation 
  An extremely helpful function to have during a power or lighting outage, it will function as NVG do for humans. The AI will be given vision in darkness such that it may remain operational in areas it is most critically needed.

*Note, This does not increase the AI's vision range! The AI has always been able to see and use machines in darkness. Blind spots as a result of damaged or missing cameras will remain. 
