### PR TITLE
Kitchen Modification 3: RETURN OF DEEP FRIED EVERYTHING

### DIFF
--- a/code/game/machinery/kitchen/cereal_maker.dm
+++ b/code/game/machinery/kitchen/cereal_maker.dm
@@ -14,11 +14,14 @@
 	if(on)
 		user << "<span class='notice'>[src] is already processing, please wait.</span>"
 		return
-	if(!istype(I, /obj/item/weapon/reagent_containers/food/snacks/))
-		user << "<span class='warning'>Budget cuts won't let you put that in there.</span>"
-		return
-	if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/cereal/))
+	if(istype(I, /obj/item/weapon/grab)||istype(I, /obj/item/tk_grab))
 		user << "<span class='warning'>That isn't going to fit.</span>"
+		return
+	if(istype(I, /obj/item/weapon/reagent_containers/glass/))
+		user << "<span class='warning'>That would probably break [src].</span>"
+		return
+	if(istype(I, /obj/item/weapon/disk/nuclear))
+		user << "Central command would kill you if you made nuke disk cereal."
 		return
 	else
 		user << "<span class='notice'>You put [I] into [src].</span>"

--- a/code/game/machinery/kitchen/cereal_maker.dm
+++ b/code/game/machinery/kitchen/cereal_maker.dm
@@ -20,6 +20,9 @@
 	if(istype(I, /obj/item/weapon/reagent_containers/glass/))
 		user << "<span class='warning'>That would probably break [src].</span>"
 		return
+	if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/cereal/))
+		user << "<span class='warning'>Cardboard cereal sound terrible.</span>"
+		return
 	if(istype(I, /obj/item/weapon/disk/nuclear))
 		user << "Central command would kill you if you made nuke disk cereal."
 		return

--- a/code/game/machinery/kitchen/deep_fryer.dm
+++ b/code/game/machinery/kitchen/deep_fryer.dm
@@ -20,11 +20,17 @@
 	if(on)
 		user << "<span class='notice'>[src] is still active!</span>"
 		return
-	if(!istype(I, /obj/item/weapon/reagent_containers/food/snacks/))
-		user << "<span class='warning'>Budget cuts won't let you put that in there.</span>"
-		return
 	if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/deepfryholder))
-		user << "<span class='userdanger'>You cannot doublefry.</span>"
+		user << "<span class='userdanger'>[I] is already deepfried.</span>"
+		return
+	if(istype(I, /obj/item/weapon/grab) || istype(I, /obj/item/tk_grab))
+		user << "<span class='warning'>That isn't going to fit.</span>"
+		return
+	if(istype(I, /obj/item/weapon/reagent_containers/glass))
+		user << "<span class='warning'>That would probably break [src].</span>"
+		return
+	if(!user.unEquip(I))
+		user << "<span class='warning'>You cannot deepfry [I].</span>"
 		return
 	else
 		user << "<span class='notice'>You put [I] into [src].</span>"
@@ -42,7 +48,6 @@
 				food.reagents.trans_to(S, food.reagents.total_volume)
 			S.color = "#FFAD33"
 			S.icon = frying.icon
-			S.overlays = I.overlays
 			S.icon_state = frying.icon_state
 			S.name = "deep fried [frying.name]"
 			S.desc = I.desc

--- a/code/game/machinery/kitchen/oven.dm
+++ b/code/game/machinery/kitchen/oven.dm
@@ -19,11 +19,8 @@
 	if(on)
 		user << "The machine is already running."
 		return
-	if(!istype(I,/obj/item/weapon/reagent_containers/food/snacks/))
-		user << "That isn't food."
-		return
 	else
-		var/obj/item/weapon/reagent_containers/food/snacks/F = I
+		var/obj/item/F = I
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/C
 		C = input("Select food to make.", "Cooking", C) in food_choices
 		if(!C)

--- a/code/game/machinery/kitchen/oven.dm
+++ b/code/game/machinery/kitchen/oven.dm
@@ -19,8 +19,11 @@
 	if(on)
 		user << "The machine is already running."
 		return
+	if(!istype(I,/obj/item/weapon/reagent_containers/food/snacks/))
+		user << "That isn't food."
+		return
 	else
-		var/obj/item/F = I
+		var/obj/item/weapon/reagent_containers/food/snacks/F = I
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/C
 		C = input("Select food to make.", "Cooking", C) in food_choices
 		if(!C)

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -1,28 +1,34 @@
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/attackby(obj/item/W as obj, mob/user as mob)
-	var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = new(get_turf(user))
-	S.attackby(W,user)
-	qdel(src)
+	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+		var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = new(get_turf(user))
+		S.attackby(W,user)
+		qdel(src)
 /obj/item/weapon/reagent_containers/food/snacks/bun/attackby(obj/item/W as obj, mob/user as mob)
-	var/obj/item/weapon/reagent_containers/food/snacks/customizable/burger/S = new(get_turf(user))
-	S.attackby(W,user)
-	qdel(src)
+	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+		var/obj/item/weapon/reagent_containers/food/snacks/customizable/burger/S = new(get_turf(user))
+		S.attackby(W,user)
+		qdel(src)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough/attackby(obj/item/W as obj, mob/user as mob)
-	var/obj/item/weapon/reagent_containers/food/snacks/customizable/pizza/S = new(get_turf(user))
-	S.attackby(W,user)
-	qdel(src)
+	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pizza/S = new(get_turf(user))
+		S.attackby(W,user)
+		qdel(src)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspagetti/attackby(obj/item/W as obj, mob/user as mob)
-	var/obj/item/weapon/reagent_containers/food/snacks/customizable/pasta/S = new(get_turf(user))
-	S.attackby(W,user)
-	qdel(src)
+
+	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pasta/S = new(get_turf(user))
+		S.attackby(W,user)
+		qdel(src)
 
 /obj/item/trash/plate/attackby(obj/item/W as obj, mob/user as mob)
-	var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/S = new(get_turf(user))
-	S.attackby(W,user)
-	qdel(src)
+	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+		var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/S = new(get_turf(user))
+		S.attackby(W,user)
+		qdel(src)
 
 /obj/item/trash/bowl
 	name = "bowl"
@@ -32,7 +38,7 @@
 
 /obj/item/trash/bowl/attackby(obj/item/W as obj, mob/user as mob)
 
-	if(istype(W,/obj/item/))
+	if(istype(W,/obj/item/weapon/shard) || istype(W,/obj/item/weapon/reagent_containers/food/snacks))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/soup/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
@@ -294,30 +300,27 @@
 	basename = "burger"
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/attackby(obj/item/W as obj, mob/user as mob)
-	var/obj/item/I = W
 	if(src.contents.len > sandwich_limit)
 		user << "<span class='warning'>If you put anything else in or on [src] it's going to make a mess.</span>"
 		return
-	if(istype(I, /obj/item/weapon/disk/nuclear))
-		user << "You think about it for a few seconds, then you realize Central Command likely doesn't find nuke disk sandwiches very funny, and so you decide not to turn the nuke disk into a foodstuff."
-		return
-	else
-		user << "<span class='notice'> You add [I] to [src].</span>"
-		if(istype(I,  /obj/item/weapon/reagent_containers/))
-			var/obj/item/weapon/reagent_containers/F = I
-			F.reagents.trans_to(src, F.reagents.total_volume)
+	else if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+		user << "<span class='notice'> You add [W] to [src].</span>"
+		var/obj/item/weapon/reagent_containers/F = W
+		F.reagents.trans_to(src, F.reagents.total_volume)
 		user.drop_item()
-		I.loc = src
-		ingredients += I
+		W.loc = src
+		ingredients += W
 		update()
+		return
+	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/proc/update()
 	var/fullname = "" //We need to build this from the contents of the var.
 	var/i = 0
 
-	overlays = 0
+	overlays.Cut()
 
-	for(var/obj/item/O in ingredients)
+	for(var/obj/item/weapon/reagent_containers/food/snacks/O in ingredients)
 
 		i++
 		if(i == 1)
@@ -335,8 +338,6 @@
 					I.color = food.filling_color
 				else
 					I.color = pick("#FF0000","#0000FF","#008000","#FFFF00")
-			else
-				I.color = pick("#FF0000","#0000FF","#008000","#FFFF00")
 			if(add_overlays)
 				I.pixel_x = pick(list(-1,0,1))
 				I.pixel_y = (i*2)+1

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -374,5 +374,5 @@
 	for(var/obj/item/O in ingredients)
 		O.loc = user.loc
 		ingredients.Remove(O)
-		updatefood()
+		update()
 	return

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -47,7 +47,7 @@
 	var/top = 1	//Do we have a top?
 	var/add_overlays = 1	//Do we stack?
 //	var/offsetstuff = 1 //Do we offset the overlays?
-	var/sandwich_limit = 40
+	var/sandwich_limit = 10
 	var/fullycustom = 0
 	trash = /obj/item/trash/plate
 	bitesize = 2

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -1,17 +1,17 @@
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+	if(istype(W,/obj/item))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
 /obj/item/weapon/reagent_containers/food/snacks/bun/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+	if(istype(W,/obj/item))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/burger/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+	if(istype(W,/obj/item))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pizza/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
@@ -19,13 +19,13 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspagetti/attackby(obj/item/W as obj, mob/user as mob)
 
-	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+	if(istype(W,/obj/item))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pasta/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
 
 /obj/item/trash/plate/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+	if(istype(W,/obj/item))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
@@ -38,7 +38,7 @@
 
 /obj/item/trash/bowl/attackby(obj/item/W as obj, mob/user as mob)
 
-	if(istype(W,/obj/item/weapon/shard) || istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+	if(istype(W,/obj/item))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/soup/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
@@ -303,10 +303,11 @@
 	if(src.contents.len > sandwich_limit)
 		user << "<span class='warning'>If you put anything else in or on [src] it's going to make a mess.</span>"
 		return
-	else if(istype(W,/obj/item/weapon/reagent_containers/food/snacks))
+	if(istype(W,/obj/item))
 		user << "<span class='notice'> You add [W] to [src].</span>"
-		var/obj/item/weapon/reagent_containers/F = W
-		F.reagents.trans_to(src, F.reagents.total_volume)
+		if(istype(W,/obj/item/weapon/reagent_containers))
+			var/obj/item/weapon/reagent_containers/F = W
+			F.reagents.trans_to(src, F.reagents.total_volume)
 		user.drop_item()
 		W.loc = src
 		ingredients += W
@@ -361,8 +362,15 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/Del()
 	for(var/obj/item/O in ingredients)
-		del(O)
+		qdel(O)
 	..()
+
+/obj/item/weapon/reagent_containers/food/snacks/customizable/attack_self(mob/user as mob)
+	..()
+	user << "You take apart [src], freeing the objects within."
+	for(var/obj/item/O in ingredients)
+		O.loc = user.loc
+	return
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/examine()
 	..()

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -373,4 +373,6 @@
 	user << "You take apart [src], freeing the objects within."
 	for(var/obj/item/O in ingredients)
 		O.loc = user.loc
+		ingredients.Remove(O)
+		updatefood()
 	return

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -1,34 +1,28 @@
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item))
-		var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = new(get_turf(user))
-		S.attackby(W,user)
-		qdel(src)
+	var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = new(get_turf(user))
+	S.attackby(W,user)
+	qdel(src)
 /obj/item/weapon/reagent_containers/food/snacks/bun/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item))
-		var/obj/item/weapon/reagent_containers/food/snacks/customizable/burger/S = new(get_turf(user))
-		S.attackby(W,user)
-		qdel(src)
+	var/obj/item/weapon/reagent_containers/food/snacks/customizable/burger/S = new(get_turf(user))
+	S.attackby(W,user)
+	qdel(src)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item))
-		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pizza/S = new(get_turf(user))
-		S.attackby(W,user)
-		qdel(src)
+	var/obj/item/weapon/reagent_containers/food/snacks/customizable/pizza/S = new(get_turf(user))
+	S.attackby(W,user)
+	qdel(src)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspagetti/attackby(obj/item/W as obj, mob/user as mob)
-
-	if(istype(W,/obj/item))
-		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pasta/S = new(get_turf(user))
-		S.attackby(W,user)
-		qdel(src)
+	var/obj/item/weapon/reagent_containers/food/snacks/customizable/pasta/S = new(get_turf(user))
+	S.attackby(W,user)
+	qdel(src)
 
 /obj/item/trash/plate/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item))
-		var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/S = new(get_turf(user))
-		S.attackby(W,user)
-		qdel(src)
+	var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/S = new(get_turf(user))
+	S.attackby(W,user)
+	qdel(src)
 
 /obj/item/trash/bowl
 	name = "bowl"
@@ -38,7 +32,7 @@
 
 /obj/item/trash/bowl/attackby(obj/item/W as obj, mob/user as mob)
 
-	if(istype(W,/obj/item))
+	if(istype(W,/obj/item/))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/soup/S = new(get_turf(user))
 		S.attackby(W,user)
 		qdel(src)
@@ -53,7 +47,7 @@
 	var/top = 1	//Do we have a top?
 	var/add_overlays = 1	//Do we stack?
 //	var/offsetstuff = 1 //Do we offset the overlays?
-	var/sandwich_limit = 10
+	var/sandwich_limit = 40
 	var/fullycustom = 0
 	trash = /obj/item/trash/plate
 	bitesize = 2
@@ -300,28 +294,30 @@
 	basename = "burger"
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/attackby(obj/item/W as obj, mob/user as mob)
+	var/obj/item/I = W
 	if(src.contents.len > sandwich_limit)
 		user << "<span class='warning'>If you put anything else in or on [src] it's going to make a mess.</span>"
 		return
-	if(istype(W,/obj/item))
-		user << "<span class='notice'> You add [W] to [src].</span>"
-		if(istype(W,/obj/item/weapon/reagent_containers))
-			var/obj/item/weapon/reagent_containers/F = W
+	if(istype(I, /obj/item/weapon/disk/nuclear))
+		user << "You think about it for a few seconds, then you realize Central Command likely doesn't find nuke disk sandwiches very funny, and so you decide not to turn the nuke disk into a foodstuff."
+		return
+	else
+		user << "<span class='notice'> You add [I] to [src].</span>"
+		if(istype(I,  /obj/item/weapon/reagent_containers/))
+			var/obj/item/weapon/reagent_containers/F = I
 			F.reagents.trans_to(src, F.reagents.total_volume)
 		user.drop_item()
-		W.loc = src
-		ingredients += W
+		I.loc = src
+		ingredients += I
 		update()
-		return
-	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/proc/update()
 	var/fullname = "" //We need to build this from the contents of the var.
 	var/i = 0
 
-	overlays.Cut()
+	overlays = 0
 
-	for(var/obj/item/weapon/reagent_containers/food/snacks/O in ingredients)
+	for(var/obj/item/O in ingredients)
 
 		i++
 		if(i == 1)
@@ -339,6 +335,8 @@
 					I.color = food.filling_color
 				else
 					I.color = pick("#FF0000","#0000FF","#008000","#FFFF00")
+			else
+				I.color = pick("#FF0000","#0000FF","#008000","#FFFF00")
 			if(add_overlays)
 				I.pixel_x = pick(list(-1,0,1))
 				I.pixel_y = (i*2)+1
@@ -362,18 +360,17 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/Del()
 	for(var/obj/item/O in ingredients)
-		qdel(O)
+		del(O)
 	..()
-
-/obj/item/weapon/reagent_containers/food/snacks/customizable/attack_self(mob/user as mob)
-	..()
-	user << "You take apart [src], freeing the objects within."
-	for(var/obj/item/O in ingredients)
-		O.loc = user.loc
-	return
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/examine()
 	..()
 	var/whatsinside = pick(ingredients)
 
 	usr << "<span class='notice'> You think you can see [whatsinside] in there.</span>"
+/obj/item/weapon/reagent_containers/food/snacks/customizable/attack_self(mob/user as mob)
+	..()
+	user << "You take apart [src], freeing the objects within."
+	for(var/obj/item/O in ingredients)
+		O.loc = user.loc
+	return


### PR DESCRIPTION
So I got the results back on that Deep Fried Everything user poll.
http://www.ss13.eu/tgdb/nt/ingamepolls.php

66 voted for keeping Deep fried everything, 40 for not keeping it, and 11 abstained.

As such, I'm bringing it back.

You cannot deep fry, cerealize, or candyize the nuke disk, rest easy nuke ops.

You can also take apart sandwiches and such by clicking on it in hand, allowing you to save the contents of the sandwich.
