### PR TITLE
fixes exploits with the mech fabricator (NTstation13)

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -355,6 +355,11 @@
 
 /obj/machinery/mecha_part_fabricator/proc/build_part(var/obj/item/part)
 	if(!part) return
+	
+	 // critical exploit prevention, do not remove unless you replace it -walter0o
+	if( !(locate(part, src.contents)) || !(part.vars.Find("construction_time")) || !(part.vars.Find("construction_cost")) ) // these 3 are the current requirements for an object being buildable by the mech_fabricator
+		return
+	
 	src.being_built = new part.type(src)
 	src.desc = "It's building \a [src.being_built]."
 	src.remove_resources(part)
@@ -603,6 +608,20 @@
 	onclose(user, "mecha_fabricator")
 	return
 
+/obj/machinery/mecha_part_fabricator/proc/exploit_prevention(var/obj/Part, mob/user as mob, var/desc_exploit)
+// critical exploit prevention, feel free to improve or replace this, but do not remove it -walter0o
+	
+	if(!Part || !user || !istype(Part) || !istype(user)) // sanity
+		return 1
+	
+	if( !(locate(Part, src.contents)) || !(Part.vars.Find("construction_time")) || !(Part.vars.Find("construction_cost")) ) // these 3 are the current requirements for an object being buildable by the mech_fabricator
+	
+		var/turf/LOC = get_turf(user)
+		message_admins("[key_name_admin(user)] tried to exploit an Exosuit Fabricator to [desc_exploit ? "get the desc of" : "duplicate"] <a href='?_src_=vars;Vars=\ref[Part]'>[Part]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
+		log_admin("EXPLOIT : [key_name(user)] tried to exploit an Exosuit Fabricator to [desc_exploit ? "get the desc of" : "duplicate"] [Part] !")		
+		return 1
+	
+	return null
 
 /obj/machinery/mecha_part_fabricator/Topic(href, href_list)
 	if(..())
@@ -617,13 +636,25 @@
 				src.part_set = tpart_set
 				screen = "parts"
 	if(href_list["part"])
-		var/list/part = filter.getObj("part")
+		var/obj/part = filter.getObj("part")
+		
+		// critical exploit prevention, do not remove unless you replace it -walter0o
+		if(src.exploit_prevention(part, usr))
+			return
+		
 		if(!processing_queue)
 			build_part(part)
 		else
 			add_to_queue(part)
 	if(href_list["add_to_queue"])
-		add_to_queue(filter.getObj("add_to_queue"))
+		var/obj/part = filter.getObj("add_to_queue")
+		
+		// critical exploit prevention, do not remove unless you replace it -walter0o
+		if(src.exploit_prevention(part, usr))
+			return
+			
+		add_to_queue(part)
+		
 		return update_queue_on_page()
 	if(href_list["remove_from_queue"])
 		remove_from_queue(filter.getNum("remove_from_queue"))
@@ -662,6 +693,11 @@
 		return update_queue_on_page()
 	if(href_list["part_desc"])
 		var/obj/part = filter.getObj("part_desc")
+		
+		// critical exploit prevention, do not remove unless you replace it -walter0o
+		if(src.exploit_prevention(part, usr, 1))
+			return
+		
 		if(part)
 			temp = {"<h1>[part] description:</h1>
 						[part.desc]<br>


### PR DESCRIPTION
this exploit is in all public builds i could look at.

using the mech fabricator, and you were able to duplicate any obj in the server.

as a nice bonus you could also abuse the part-description-function to identify any atom in the server
memory for even easier access to other yet unknown exploits of this kind.

i will not go into details, as it is exactly the same kind of exploit over and over, 
so if you are interested on how and why these exploits work, see some of my other exploit commits :
https://github.com/NTStation/NTstation13/commit/8314044aaeb0654ec9076d293bb6b8b67121d82b
https://github.com/Baystation12/Baystation12/pull/5068

i advise any coder team to be supercautious when changing/writing new Topic procs to prevent these,
and to always doublecheck other coder's works.
