### PR TITLE
airalarm exploit fixes

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -528,7 +528,8 @@ table tr:first-child th:first-child { border: none;}
 			usr << browse(null, "window=air_alarm")
 			return
 
-
+	if(locked && !istype(usr, /mob/living/silicon)) // exploit prevention -walter0o
+		return
 
 	if(href_list["command"])
 		var/device_id = href_list["id_tag"]


### PR DESCRIPTION
airalarm had check missing to make sure the AA
was unlocked before triggering panicsyphon and the like.
