### PR TITLE
admin permissions

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -221,21 +221,21 @@ var/global/floorIsLava = 0
 		if(6)
 			dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed story to Network.</B></FONT><HR><BR>"
 			if(src.admincaster_feed_channel.channel_name=="")
-				dat+="<FONT COLOR='maroon'>•Invalid receiving channel name.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>ï¿½Invalid receiving channel name.</FONT><BR>"
 			if(src.admincaster_feed_message.body == "" || src.admincaster_feed_message.body == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>•Invalid message body.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>ï¿½Invalid message body.</FONT><BR>"
 			dat+="<BR><A href='?src=\ref[src];ac_setScreen=[3]'>Return</A><BR>"
 		if(7)
 			dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed Channel to Network.</B></FONT><HR><BR>"
 			if(src.admincaster_feed_channel.channel_name =="" || src.admincaster_feed_channel.channel_name == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>•Invalid channel name.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>ï¿½Invalid channel name.</FONT><BR>"
 			var/check = 0
 			for(var/datum/feed_channel/FC in news_network.network_channels)
 				if(FC.channel_name == src.admincaster_feed_channel.channel_name)
 					check = 1
 					break
 			if(check)
-				dat+="<FONT COLOR='maroon'>•Channel name already in use.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>ï¿½Channel name already in use.</FONT><BR>"
 			dat+="<BR><A href='?src=\ref[src];ac_setScreen=[2]'>Return</A><BR>"
 		if(9)
 			dat+="<B>[src.admincaster_feed_channel.channel_name]: </B><FONT SIZE=1>\[created by: <FONT COLOR='maroon'>[src.admincaster_feed_channel.author]</FONT>\]</FONT><HR>"
@@ -330,9 +330,9 @@ var/global/floorIsLava = 0
 		if(16)
 			dat+="<B><FONT COLOR='maroon'>ERROR: Wanted Issue rejected by Network.</B></FONT><HR><BR>"
 			if(src.admincaster_feed_message.author =="" || src.admincaster_feed_message.author == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>•Invalid name for person wanted.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>ï¿½Invalid name for person wanted.</FONT><BR>"
 			if(src.admincaster_feed_message.body == "" || src.admincaster_feed_message.body == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>•Invalid description.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>ï¿½Invalid description.</FONT><BR>"
 			dat+="<BR><A href='?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>"
 		if(17)
 			dat+="<B>Wanted Issue successfully deleted from Circulation</B><BR>"
@@ -398,7 +398,9 @@ var/global/floorIsLava = 0
 	if(!check_rights(0))	return
 
 	var/dat = "<B>The first rule of adminbuse is: you don't talk about the adminbuse.</B><HR>"
-
+	if(!check_rights(R_ADMIN))
+		usr << browse(dat, "window=secrets")
+		return
 	dat +={"
 			<B>General Secrets</B><BR>
 			<BR>

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -398,9 +398,6 @@ var/global/floorIsLava = 0
 	if(!check_rights(0))	return
 
 	var/dat = "<B>The first rule of adminbuse is: you don't talk about the adminbuse.</B><HR>"
-	if(!check_rights(R_ADMIN))
-		usr << browse(dat, "window=secrets")
-		return
 	dat +={"
 			<B>General Secrets</B><BR>
 			<BR>

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -25,6 +25,7 @@
 /client/proc/investigate_show( subject in list("hrefs","notes","ntsl","singulo","wires","telesci", "gravity") )
 	set name = "Investigate"
 	set category = "Admin"
+	if(!check_rights(R_ADMIN))	return
 	if(!holder)	return
 	switch(subject)
 		if("singulo", "ntsl", "wires", "telesci", "gravity")			//general one-round-only stuff

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -25,7 +25,6 @@
 /client/proc/investigate_show( subject in list("hrefs","notes","ntsl","singulo","wires","telesci", "gravity") )
 	set name = "Investigate"
 	set category = "Admin"
-	if(!check_rights(R_ADMIN))	return
 	if(!holder)	return
 	switch(subject)
 		if("singulo", "ntsl", "wires", "telesci", "gravity")			//general one-round-only stuff

--- a/code/modules/admin/admin_memo.dm
+++ b/code/modules/admin/admin_memo.dm
@@ -6,7 +6,7 @@
 	set name = "Memo"
 	set category = "Server"
 	if(!ENABLE_MEMOS)		return
-	if(!check_rights(0))	return
+	if(!check_rights(R_ADMIN))	return
 	switch(task)
 		if("write")		admin_memo_write()
 		if("show")		admin_memo_show()
@@ -14,6 +14,7 @@
 
 //write a message
 /client/proc/admin_memo_write()
+	if(!check_rights(R_ADMIN))	return
 	var/savefile/F = new(MEMOFILE)
 	if(F)
 		var/memo = input(src,"Type your memo\n(Leaving it blank will delete your current memo):","Write Memo",null) as null|message
@@ -31,6 +32,7 @@
 
 //show all memos
 /client/proc/admin_memo_show()
+	if(!check_rights(R_ADMIN))	return
 	if(ENABLE_MEMOS)
 		var/savefile/F = new(MEMOFILE)
 		if(F)
@@ -39,6 +41,7 @@
 
 //delete your own or somebody else's memo
 /client/proc/admin_memo_delete()
+	if(!check_rights(R_ADMIN))	return
 	var/savefile/F = new(MEMOFILE)
 	if(F)
 		var/ckey

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,6 +1,6 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
-	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
+	/client/proc/deadmin_self			/*destroys our own admin datum so we can play as a regular player*/
 	)
 var/list/admin_verbs_admin = list(
 	/client/proc/player_panel,			/*shows an interface for all players, with links to various panels (old style)*/
@@ -41,7 +41,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_direct_narrate,	/*send text directly to a player with no padding. Useful for narratives and fluff-text*/
 	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/
 	/client/proc/cmd_admin_create_centcom_report,
-	/client/proc/check_words			/*displays cult-words*/
+	/client/proc/check_words,			/*displays cult-words*/
 	/client/proc/cmd_admin_say,			/*admin-only ooc chat*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
 	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
@@ -56,7 +56,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/reload_admins,
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel		/*admin-pm list*/
-	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
+	/client/proc/toggleadminhelpsound	/*toggles whether we hear a sound when adminhelps/PMs are used*/
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,6 +1,14 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
-	/client/proc/deadmin_self			/*destroys our own admin datum so we can play as a regular player*/
+	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
+	/client/proc/secrets,
+	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
+	/client/proc/Jump,
+	/client/proc/jumptokey,				/*allows us to jump to the location of a mob with a certain ckey*/
+	/client/proc/jumptomob,				/*allows us to jump to a specific mob*/
+	/client/proc/jumptoturf,			/*allows us to jump to a specific turf*/
+	/client/proc/jumptocoord,			/*we ghost and jump to a coordinate*/
+	/client/proc/jumptomob			/*allows us to jump to a specific mob*/
 	)
 var/list/admin_verbs_admin = list(
 	/client/proc/player_panel,			/*shows an interface for all players, with links to various panels (old style)*/
@@ -28,14 +36,9 @@ var/list/admin_verbs_admin = list(
 	/client/proc/giveruntimelog,		/*allows us to give access to runtime logs to somebody*/
 	/client/proc/getruntimelog,			/*allows us to access runtime logs to somebody*/
 	/client/proc/getserverlog,			/*allows us to fetch server logs (diary) for other days*/
-	/client/proc/jumptocoord,			/*we ghost and jump to a coordinate*/
 	/client/proc/Getmob,				/*teleports a mob to our location*/
 	/client/proc/Getkey,				/*teleports a mob with a certain ckey to our location*/
 //	/client/proc/sendmob,				/*sends a mob somewhere*/ -Removed due to it needing two sorting procs to work, which were executed every time an admin right-clicked. ~Errorage
-	/client/proc/Jump,
-	/client/proc/jumptokey,				/*allows us to jump to the location of a mob with a certain ckey*/
-	/client/proc/jumptomob,				/*allows us to jump to a specific mob*/
-	/client/proc/jumptoturf,			/*allows us to jump to a specific turf*/
 	/client/proc/admin_call_shuttle,	/*allows us to call the emergency shuttle*/
 	/client/proc/admin_cancel_shuttle,	/*allows us to cancel the emergency shuttle, sending it back to centcom*/
 	/client/proc/cmd_admin_direct_narrate,	/*send text directly to a player with no padding. Useful for narratives and fluff-text*/
@@ -51,8 +54,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/dsay,					/*talk in deadchat using our ckey/fakekey*/
 	/client/proc/toggleprayers,			/*toggles prayers on/off*/
 	/client/proc/toggle_hear_radio,		/*toggles whether we hear the radio*/
-	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
-	/client/proc/secrets,
 	/client/proc/reload_admins,
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -55,7 +55,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/secrets,
 	/client/proc/reload_admins,
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
-	/client/proc/cmd_admin_pm_panel		/*admin-pm list*/
+	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/
 	/client/proc/toggleadminhelpsound	/*toggles whether we hear a sound when adminhelps/PMs are used*/
 	)
 var/list/admin_verbs_ban = list(

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,21 +1,6 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
-	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
 	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
-	/client/proc/cmd_admin_say,			/*admin-only ooc chat*/
-	/client/proc/hide_verbs,			/*hides all our adminverbs*/
-	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
-	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
-	/client/proc/admin_memo,			/*admin memo system. show/delete/write. +SERVER needed to delete admin memos of others*/
-	/client/proc/deadchat,				/*toggles deadchat on/off*/
-	/client/proc/dsay,					/*talk in deadchat using our ckey/fakekey*/
-	/client/proc/toggleprayers,			/*toggles prayers on/off*/
-	/client/proc/toggle_hear_radio,		/*toggles whether we hear the radio*/
-	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
-	/client/proc/secrets,
-	/client/proc/reload_admins,
-	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
-	/client/proc/cmd_admin_pm_panel		/*admin-pm list*/
 	)
 var/list/admin_verbs_admin = list(
 	/client/proc/player_panel,			/*shows an interface for all players, with links to various panels (old style)*/
@@ -57,6 +42,21 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/
 	/client/proc/cmd_admin_create_centcom_report,
 	/client/proc/check_words			/*displays cult-words*/
+	/client/proc/cmd_admin_say,			/*admin-only ooc chat*/
+	/client/proc/hide_verbs,			/*hides all our adminverbs*/
+	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
+	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
+	/client/proc/admin_memo,			/*admin memo system. show/delete/write. +SERVER needed to delete admin memos of others*/
+	/client/proc/deadchat,				/*toggles deadchat on/off*/
+	/client/proc/dsay,					/*talk in deadchat using our ckey/fakekey*/
+	/client/proc/toggleprayers,			/*toggles prayers on/off*/
+	/client/proc/toggle_hear_radio,		/*toggles whether we hear the radio*/
+	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
+	/client/proc/secrets,
+	/client/proc/reload_admins,
+	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
+	/client/proc/cmd_admin_pm_panel		/*admin-pm list*/
+	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -2,7 +2,6 @@
 	set name = "Jump to Area"
 	set desc = "Area to jump to"
 	set category = "Admin"
-	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -15,7 +14,6 @@
 /client/proc/jumptoturf(var/turf/T in world)
 	set name = "Jump to Turf"
 	set category = "Admin"
-	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -29,7 +27,6 @@
 /client/proc/jumptomob(var/mob/M in mob_list)
 	set category = "Admin"
 	set name = "Jump to Mob"
-	if(!check_rights(R_ADMIN))	return
 
 	if(!src.holder)
 		src << "Only administrators may use this command."
@@ -49,7 +46,6 @@
 /client/proc/jumptocoord(tx as num, ty as num, tz as num)
 	set category = "Admin"
 	set name = "Jump to Coordinate"
-	if(!check_rights(R_ADMIN))	return
 
 	if (!holder)
 		src << "Only administrators may use this command."
@@ -66,7 +62,6 @@
 /client/proc/jumptokey()
 	set category = "Admin"
 	set name = "Jump to Key"
-	if(!check_rights(R_ADMIN))	return
 
 	if(!src.holder)
 		src << "Only administrators may use this command."
@@ -89,7 +84,6 @@
 	set category = "Admin"
 	set name = "Get Mob"
 	set desc = "Mob to teleport"
-	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -103,7 +97,6 @@
 	set category = "Admin"
 	set name = "Get Key"
 	set desc = "Key to teleport"
-	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -127,7 +120,6 @@
 /client/proc/sendmob(var/mob/M in sortmobs())
 	set category = "Admin"
 	set name = "Send Mob"
-	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -2,6 +2,7 @@
 	set name = "Jump to Area"
 	set desc = "Area to jump to"
 	set category = "Admin"
+	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -14,6 +15,7 @@
 /client/proc/jumptoturf(var/turf/T in world)
 	set name = "Jump to Turf"
 	set category = "Admin"
+	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -27,6 +29,7 @@
 /client/proc/jumptomob(var/mob/M in mob_list)
 	set category = "Admin"
 	set name = "Jump to Mob"
+	if(!check_rights(R_ADMIN))	return
 
 	if(!src.holder)
 		src << "Only administrators may use this command."
@@ -46,6 +49,7 @@
 /client/proc/jumptocoord(tx as num, ty as num, tz as num)
 	set category = "Admin"
 	set name = "Jump to Coordinate"
+	if(!check_rights(R_ADMIN))	return
 
 	if (!holder)
 		src << "Only administrators may use this command."
@@ -62,6 +66,7 @@
 /client/proc/jumptokey()
 	set category = "Admin"
 	set name = "Jump to Key"
+	if(!check_rights(R_ADMIN))	return
 
 	if(!src.holder)
 		src << "Only administrators may use this command."
@@ -84,6 +89,7 @@
 	set category = "Admin"
 	set name = "Get Mob"
 	set desc = "Mob to teleport"
+	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -97,7 +103,7 @@
 	set category = "Admin"
 	set name = "Get Key"
 	set desc = "Key to teleport"
-
+	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
@@ -121,6 +127,7 @@
 /client/proc/sendmob(var/mob/M in sortmobs())
 	set category = "Admin"
 	set name = "Send Mob"
+	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -2,6 +2,7 @@
 /client/proc/cmd_admin_pm_context(mob/M as mob in mob_list)
 	set category = null
 	set name = "Admin PM Mob"
+	if(!check_rights(R_ADMIN))	return
 	if(!holder)
 		src << "<font color='red'>Error: Admin-PM-Context: Only administrators may use this command.</font>"
 		return
@@ -13,6 +14,7 @@
 /client/proc/cmd_admin_pm_panel()
 	set category = "Admin"
 	set name = "Admin PM"
+	if(!check_rights(R_ADMIN))	return
 	if(!holder)
 		src << "<font color='red'>Error: Admin-PM-Panel: Only administrators may use this command.</font>"
 		return

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -2,7 +2,7 @@
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
-	if(!check_rights(0))	return
+	if(!check_rights(R_ADMIN))	return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)	return

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -2,6 +2,7 @@
 	set category = "Special Verbs"
 	set name = "Dsay" //Gave this shit a shorter name so you only have to time out "dsay" rather than "dead say" to use it --NeoFite
 	set hidden = 1
+	if(!check_rights(R_ADMIN))	return
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -4,7 +4,7 @@ var/sound/admin_sound
 /client/proc/play_sound(S as sound)
 	set category = "Fun"
 	set name = "Play Global Sound"
-	if(!check_rights(R_SOUNDS))	return
+	if(!check_rights(R_SERVER))	return
 
 	admin_sound = sound(S, repeat = 0, wait = 1, channel = SOUND_CHANNEL_ADMIN)
 	admin_sound.priority = 250
@@ -12,10 +12,6 @@ var/sound/admin_sound
 
 	log_admin("[key_name(src)] played sound [S]")
 	message_admins("[key_name_admin(src)] played sound [S]", 1)
-
-	if(events.holiday == "April Fool's Day")
-		admin_sound.frequency = pick(0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1.1, 1.2, 1.4, 1.6, 2.0, 2.5)
-		src << "You feel the Honkmother messing with your song..."
 
 	for(var/mob/M in player_list)
 		if(M.client.prefs.toggles & SOUND_MIDI)
@@ -29,7 +25,7 @@ var/sound/admin_sound
 /client/proc/play_local_sound(S as sound)
 	set category = "Fun"
 	set name = "Play Local Sound"
-	if(!check_rights(R_SOUNDS))	return
+	if(!check_rights(R_SERVER))	return
 
 	log_admin("[key_name(src)] played a local sound [S]")
 	message_admins("[key_name_admin(src)] played a local sound [S]", 1)
@@ -39,7 +35,7 @@ var/sound/admin_sound
 /client/proc/stop_sounds()
 	set category = "Debug"
 	set name = "Stop Sounds"
-	if((check_rights(R_SOUNDS)) || (check_rights(R_DEBUG)))
+	if((check_rights(R_SERVER)) || (check_rights(R_DEBUG)))
 
 		log_admin("[key_name(src)] stopped all currently playing sounds.")
 		message_admins("[key_name_admin(src)] stopped all currently playing sounds.")


### PR DESCRIPTION
why people w/o +ADMIN could use admin stuff, I don't know.

this makes shit that should of had +ADMIN actually require +ADMIN. by default someone in the TXT only gets deadmin self, investigate, and the jumps now. if you don't have +ADMIN you don't need anything other then those.
