### PR TITLE
Retaliate() now only gets called if the mob is alive/conscious.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -46,4 +46,5 @@
 
 /mob/living/simple_animal/hostile/retaliate/adjustBruteLoss(var/damage)
 	..(damage)
-	Retaliate()
+	if(stat == CONSCIOUS)
+		Retaliate()


### PR DESCRIPTION
Should fix some bugs with simple mobs. Example: You kick Pete while it is dead, "Pete gets an evil looking gleam in his eye." even though Pete is dead. rip feature.
