### PR TITLE
Upgradeable kinetic guns, small kinetic charge buff

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -22,6 +22,8 @@
 	var/obj/item/ammo_casing/chambered = null
 	var/trigger_guard = 1
 
+	var/list/upgrades = list()
+
 /obj/item/weapon/gun/proc/process_chamber()
 	return 0
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -107,10 +107,30 @@
 	cell_type = "/obj/item/weapon/stock_parts/cell/crap"
 	var/overheat = 0
 	var/recent_reload = 1
+	var/overheat_time = 20
+	var/list/upgrades = list("diamond" = 0, "screwdriver" = 0)
+
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/screwdriver) && upgrades["screwdriver"] < 3)
+		upgrades["screwdriver"]++
+		overheat_time -= 1
+		user << "<span class='info'>You tweak [src]'s thermal exchanger.</span>"
+
+
+	else if(istype(W, /obj/item/stack))
+		var/obj/item/stack/S = W
+
+		if(istype(S, /obj/item/stack/sheet/mineral/diamond) && upgrades["diamond"] < 3)
+			upgrades["diamond"]++
+			overheat_time -= 3
+			user << "<span class='info'>You upgrade [src]'s thermal exchanger with diamonds.</span>"
+			S.use(1)
+
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/shoot_live_shot()
 	overheat = 1
-	spawn(20)
+	spawn(overheat_time)
 		overheat = 0
 		recent_reload = 0
 	..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -109,7 +109,7 @@
 	var/recent_reload = 1
 	var/range_add = 0
 	var/overheat_time = 20
-	var/list/upgrades = list("diamond" = 0, "screwdriver" = 0, "plasma" = 0)
+	upgrades = list("diamond" = 0, "screwdriver" = 0, "plasma" = 0)
 
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/newshot()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -139,7 +139,7 @@
 			upgrades["plasma"]++
 			range_add++
 			user << "<span class='info'>You upgrade [src]'s accelerating chamber with plasma.</span>"
-			if(prob(5 * (range_add + 1)) && power_supply)
+			if(prob(5 * (range_add + 1) * (range_add + 1)) && power_supply)
 				power_supply.rigged = 1 // This is dangerous!
 			S.use(1)
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -107,8 +107,16 @@
 	cell_type = "/obj/item/weapon/stock_parts/cell/crap"
 	var/overheat = 0
 	var/recent_reload = 1
+	var/range_add = 0
 	var/overheat_time = 20
-	var/list/upgrades = list("diamond" = 0, "screwdriver" = 0)
+	var/list/upgrades = list("diamond" = 0, "screwdriver" = 0, "plasma" = 0)
+
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/newshot()
+	..()
+	if(chambered && chambered.BB)
+		var/obj/item/projectile/kinetic/charge = chambered.BB
+		charge.range += range_add
 
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -125,6 +133,14 @@
 			upgrades["diamond"]++
 			overheat_time -= 3
 			user << "<span class='info'>You upgrade [src]'s thermal exchanger with diamonds.</span>"
+			S.use(1)
+
+		if(istype(S, /obj/item/stack/sheet/mineral/plasma) && upgrades["plasma"] < 2)
+			upgrades["plasma"]++
+			range_add++
+			user << "<span class='info'>You upgrade [src]'s accelerating chamber with plasma.</span>"
+			if(prob(5 * (range_add + 1)) && power_supply)
+				power_supply.rigged = 1 // This is dangerous!
 			S.use(1)
 
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -161,13 +161,20 @@ obj/item/projectile/kinetic/New()
 	var/pressure = environment.return_pressure()
 	if(pressure < 50)
 		name = "full strength kinetic force"
-		damage = 30
+		damage *= 2
 	..()
 
 /obj/item/projectile/kinetic/Range()
 	range--
 	if(range <= 0)
 		new /obj/item/effect/kinetic_blast(src.loc)
+
+		for(var/turf/T in range(1, src.loc))
+			if(!istype(T, /turf/simulated/wall))
+				T.ex_act(3)
+
+		for(var/obj/structure/S in range(1, src.loc))
+			S.ex_act(3)
 		delete()
 
 /obj/item/projectile/kinetic/on_hit(var/atom/target)
@@ -176,6 +183,12 @@ obj/item/projectile/kinetic/New()
 		var/turf/simulated/mineral/M = target_turf
 		M.gets_drilled()
 	new /obj/item/effect/kinetic_blast(target_turf)
+	for(var/turf/T in range(1, target_turf))
+		if(!istype(T, /turf/simulated/wall))
+			T.ex_act(3)
+
+	for(var/obj/structure/S in range(1, target_turf))
+		S.ex_act(3)
 	..()
 
 /obj/item/effect/kinetic_blast
@@ -185,12 +198,5 @@ obj/item/projectile/kinetic/New()
 	layer = 4.1
 
 /obj/item/effect/kinetic_blast/New()
-	for(var/turf/T in range(1))
-		if(!istype(T, /turf/simulated/wall))
-			T.ex_act(3)
-
-	for(var/obj/structure/S in range(1))
-		S.ex_act(3)
-
 	spawn(4)
 		qdel(src)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -183,12 +183,14 @@ obj/item/projectile/kinetic/New()
 		var/turf/simulated/mineral/M = target_turf
 		M.gets_drilled()
 	new /obj/item/effect/kinetic_blast(target_turf)
-	for(var/turf/T in range(1, target_turf))
-		if(!istype(T, /turf/simulated/wall))
-			T.ex_act(3)
 
-	for(var/obj/structure/S in range(1, target_turf))
-		S.ex_act(3)
+	if(isturf(target) || istype(target, /obj/structure))
+		for(var/turf/T in range(1, target_turf))
+			if(!istype(T, /turf/simulated/wall))
+				T.ex_act(3)
+
+		for(var/obj/structure/S in range(1, target_turf))
+			S.ex_act(3)
 	..()
 
 /obj/item/effect/kinetic_blast

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -185,5 +185,12 @@ obj/item/projectile/kinetic/New()
 	layer = 4.1
 
 /obj/item/effect/kinetic_blast/New()
+	for(var/turf/T in range(1))
+		if(!istype(T, /turf/simulated/wall))
+			T.ex_act(3)
+
+	for(var/obj/structure/S in range(1))
+		S.ex_act(3)
+
 	spawn(4)
 		qdel(src)


### PR DESCRIPTION
You can reduce kinetic gun's cooldown by tweaking or upgrading it's thermal exchanger. 
Maximally upgraded gun's cooldown is 8, standard is 20.

You can increase kinetic gun's range with plasma sheets (up to 5, current is 3), but this can make your gun unsafe.

Kinetic charge is buffed a bit and can damage structures and turfs around the kinetic blast (but not station walls or mobs). This makes kinetic guns a bit better in mining.
