### PR TITLE
Fixes pAI and AI SecHUDs showing one ID at a time

### DIFF
--- a/code/modules/mob/living/silicon/pai/hud.dm
+++ b/code/modules/mob/living/silicon/pai/hud.dm
@@ -26,7 +26,7 @@ mob/living/silicon/proc/securityHUD(mob/living/silicon/S as mob)
 						if("Parolled")		holder.icon_state = "hudparolled"
 						if("Released")		holder.icon_state = "hudreleased"
 						else
-							return
+							continue
 					client.images += holder
 
 /mob/living/silicon/proc/medicalHUD(mob/living/silicon/S as mob)


### PR DESCRIPTION
The proc was prematurely terminated due to a "return" instead of a
"continue" command in the loop.
