### PR TITLE
New traitor item: Chempen

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -266,6 +266,13 @@ var/list/uplink_items = list()
 	cost = 4
 	excludefrom = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_weapons/chem_pen
+	name = "Chem Pen"
+	desc = "A multiuse air-needle injector disguised as a functional pen, filled with a strong sedative that will knock out targets after a few seconds. Comes with 3 uses and can be refilled with any other chemical of your choice."
+	item = /obj/item/weapon/pen/chem
+	cost = 5
+	excludefrom = list(/datum/game_mode/nuclear) //is this really needed?
+
 /datum/uplink_item/stealthy_weapons/soap
 	name = "Syndicate Soap"
 	desc = "A sinister-looking surfactant used to clean blood stains to hide murders and prevent DNA analysis. You can also drop it underfoot to slip people."

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -75,3 +75,21 @@
 	reagents.add_reagent("impedrezene", 25)
 	reagents.add_reagent("cryptobiolin", 15)
 	..()
+
+/obj/item/weapon/pen/chem
+	origin_tech = "materials=2;syndicate=5"
+	flags = OPENCONTAINER
+
+/obj/item/weapon/pen/chem/New()
+	create_reagents(30)
+	reagents.add_reagent("chloralhydrate", 30)
+	..()
+
+
+/obj/item/weapon/pen/chem/attack(mob/living/M, mob/user)
+	if(!istype(M))	return
+
+	if(..())
+		if(reagents.total_volume)
+			if(M.reagents)
+				reagents.trans_to(M, 10)


### PR DESCRIPTION
Adds a new traitor item to the uplink: The chempen.

It's a pen that can hold 30u of chemicals and injects 10u per stab into the victim. Unlike the parapen, it can be refilled with any chemical of your choice. It costs 5 telecrystals. Not avaible to nukeops.

The pen comes prefilled with chloral as was voted on here: http://tgstation13.org/phpBB/viewtopic.php?f=15&t=763 (technically a tie but I did not vote there and I prefer the chloral version)

A note about chloral: 
*The 30u that start in the pen are NOT enough to kill or even heavily injure someone. In fact, the victim will wake up as soon as they start takings damage from the reagent.

Link to poll: http://tgstation13.org/phpBB/viewtopic.php?f=14&t=924
