### PR TITLE
Updates internals button, removes breathing from plasma tanks.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -205,48 +205,20 @@
 		if("internal")
 			if(iscarbon(usr))
 				var/mob/living/carbon/C = usr
-				if(!C.stat && !C.stunned && !C.paralysis && !C.restrained())
+				if(C.canmove && !C.restrained())
 					if(C.internal)
 						C.internal = null
-						C << "<span class='notice'>No longer running on internals.</span>"
+						C << "<span class='notice'>No longer breathing from internals.</span>"
 						if(C.internals)
 							C.internals.icon_state = "internal0"
 					else
-						if(!istype(C.wear_mask, /obj/item/clothing/mask))
-							C << "<span class='notice'>You are not wearing a mask.</span>"
-							return 1
+						C.internal = C.get_airtank()
+						if(C.internal)
+							C <<"<span class='notice'>You are now breathing from your [C.internal].</span>"
+							if(C.internals)
+								C.internals.icon_state = "internal1"
 						else
-							if(istype(C.l_hand, /obj/item/weapon/tank))
-								C << "<span class='notice'>You are now running on internals from the [C.l_hand] on your left hand.</span>"
-								C.internal = C.l_hand
-							else if(istype(C.r_hand, /obj/item/weapon/tank))
-								C << "<span class='notice'>You are now running on internals from the [C.r_hand] on your right hand.</span>"
-								C.internal = C.r_hand
-							else if(ishuman(C))
-								var/mob/living/carbon/human/H = C
-								if(istype(H.s_store, /obj/item/weapon/tank))
-									H << "<span class='notice'>You are now running on internals from the [H.s_store] on your [H.wear_suit].</span>"
-									H.internal = H.s_store
-								else if(istype(H.belt, /obj/item/weapon/tank))
-									H << "<span class='notice'>You are now running on internals from the [H.belt] on your belt.</span>"
-									H.internal = H.belt
-								else if(istype(H.l_store, /obj/item/weapon/tank))
-									H << "<span class='notice'>You are now running on internals from the [H.l_store] in your left pocket.</span>"
-									H.internal = H.l_store
-								else if(istype(H.r_store, /obj/item/weapon/tank))
-									H << "<span class='notice'>You are now running on internals from the [H.r_store] in your right pocket.</span>"
-									H.internal = H.r_store
-
-							//Seperate so CO2 jetpacks are a little less cumbersome.
-							if(!C.internal && istype(C.back, /obj/item/weapon/tank))
-								C << "<span class='notice'>You are now running on internals from the [C.back] on your back.</span>"
-								C.internal = C.back
-
-							if(C.internal)
-								if(C.internals)
-									C.internals.icon_state = "internal1"
-							else
-								C << "<span class='notice'>You don't have an oxygen tank.</span>"
+							C << "<span class='notice'>You don't have an internals tank!</span>"
 		if("act_intent")
 			usr.a_intent_change("right")
 		if("pull")

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -212,9 +212,13 @@
 						if(C.internals)
 							C.internals.icon_state = "internal0"
 					else
+						if(!istype(C.wear_mask, /obj/item/clothing/mask))
+							C << "<span class='notice'>You are not wearing an internals-compliant mask.</span>"
+							return 1
+
 						C.internal = C.get_airtank()
 						if(C.internal)
-							C <<"<span class='notice'>You are now breathing from your [C.internal].</span>"
+							C <<"<span class='notice'>You are now breathing from [C.internal].</span>"
 							if(C.internals)
 								C.internals.icon_state = "internal1"
 						else

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -96,6 +96,7 @@
 	distribute_pressure = 0
 	icon_state = "jetpack-black"
 	item_state =  "jetpack-black"
+	canbreathe = 0
 
 	New()
 		..()

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -91,6 +91,7 @@
 	name = "plasma tank"
 	desc = "Contains dangerous plasma. Do not inhale. Warning: extremely flammable."
 	icon_state = "plasma"
+	canbreathe = 0
 	flags = CONDUCT
 	slot_flags = null	//they have no straps!
 

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -16,6 +16,7 @@
 	var/distribute_pressure = ONE_ATMOSPHERE
 	var/integrity = 3
 	var/volume = 70
+	var/canbreathe = 1
 
 /obj/item/weapon/tank/New()
 	..()
@@ -92,6 +93,10 @@
 
 	if(istype(W, /obj/item/device/assembly_holder))
 		bomb_assemble(W,user)
+
+	if(istype(W, /obj/item/weapon/wirecutters) && canbreathe == 0)
+		usr << "<span class='notice'>You snip the safety valve from the tank, allowing it to connect to internals.</span>"
+		canbreathe = 1
 
 /obj/item/weapon/tank/attack_self(mob/user as mob)
 	if (!(src.air_contents))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -802,3 +802,17 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/activate_hand(var/selhand) //0 or "r" or "right" for right hand; 1 or "l" or "left" for left hand.
 	return
 
+/mob/proc/get_airtank()
+    return null
+
+/mob/living/carbon/get_airtank()
+    for(var/obj/item/weapon/tank/T in list(l_hand,r_hand, back))
+        if(T.canbreathe)
+            return T
+    return null
+/mob/living/carbon/human/get_airtank()
+    for(var/obj/item/weapon/tank/T in list(l_hand,r_hand,s_store, belt, l_store, r_store, back))
+        if(T.canbreathe)
+            return T
+    return null
+


### PR DESCRIPTION
Tanks now contain a var, canbreathe, and the internals button will only connect your mask to tanks with canbreathe = 1. This excludes plasma tanks for now, but possibly in the future this can be extended to include carbon dioxide jetpacks etc. 
