### PR TITLE
Ports Bay's AI Radio

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -69,6 +69,10 @@
 				dat += "<br>"
 				dat += {"<a href='byond://?src=\ref[src];choice=Wireless'>[A.control_disabled ? "Enable" : "Disable"] Wireless Activity</a>"}
 				dat += "<br>"
+				dat += "Subspace Transceiver is: [A.radio.disabledAi ? "Disabled" : "Enabled"]"
+				dat += "<br>"
+				dat += {"<a href='byond://?src=\ref[src];choice=Radio'>[A.radio.disabledAi ? "Enable" : "Disable"] Subspace Transceiver</a>"}
+				dat += "<br>"
 				dat += {"<a href='byond://?src=\ref[src];choice=Close'> Close</a>"}
 		user << browse(dat, "window=aicard")
 		onclose(user, "aicard")
@@ -107,6 +111,12 @@
 								A.updatehealth()
 								sleep(10)
 							flush = 0
+
+			if ("Radio")
+				for(var/mob/living/silicon/ai/A in src)
+					A.radio.disabledAi = !A.radio.disabledAi
+					A << "Your Subspace Transceiver has been: [A.radio.disabledAi ? "disabled" : "enabled"]"
+					U << "You [A.radio.disabledAi ? "Disable" : "Enable"] the AI's Subspace Transceiver"
 
 			if ("Wireless")
 				for(var/mob/living/silicon/ai/A in src)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -115,3 +115,9 @@
 	desc = "An encryption key for a radio headset.  To access the service channel, use :v."
 	icon_state = "srv_cypherkey"
 	channels = list("Service" = 1)
+
+/obj/item/device/encryptionkey/heads/ai_integrated //ported from bay, this goes 'inside' the AI.
+	name = "AI Integrated Encryption Key"
+	desc = "Integrated encryption key"
+	icon_state = "cap_cypherkey"
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -25,7 +25,9 @@
 		return
 	..()
 
-/obj/item/device/radio/headset/receive_range(freq, level)
+/obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
+	if(aiOverride)
+		return ..(freq, level)
 	if(ishuman(src.loc))
 		var/mob/living/carbon/human/H = src.loc
 		if(H.ears == src)
@@ -186,6 +188,21 @@
 	icon_state = "med_headset_alt"
 	item_state = "null"
 	keyslot2 = new /obj/item/device/encryptionkey/headset_med
+
+//The below was ported from Baystation.
+/obj/item/device/radio/headset/heads/ai_integrated //No need to care about icons, it should be hidden inside the AI anyway.
+	name = "AI Subspace Transceiver"
+	desc = "Integrated AI radio transceiver."
+	icon_state = "ai_radio"
+	item_state = "headset"
+	keyslot2 = new /obj/item/device/encryptionkey/heads/ai_integrated
+	var/myAi = null // Atlantis: Reference back to the AI which has this radio.
+	var/disabledAi = 0 // Atlantis: Used to manually disable AI's integrated radio via intellicard menu.
+
+/obj/item/device/radio/headset/heads/ai_integrated/receive_range(freq, level)
+	if(disabledAi)
+		return -1 //Transciever Disabled.
+	return ..(freq, level, 1)
 
 /obj/item/device/radio/headset/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -121,7 +121,7 @@ var/list/department_radio_keys = list(
 	else if (copytext(message, 1, 2) == ";")
 		if (ishuman(src))
 			message_mode = "headset"
-		else if(ispAI(src) || isrobot(src))
+		else if(ispAI(src) || isrobot(src) || isAI(src))
 			message_mode = "pAI"
 		message = copytext(message, 2)
 
@@ -132,7 +132,7 @@ var/list/department_radio_keys = list(
 		//world << "channel_prefix=[channel_prefix]; message_mode=[message_mode]"
 		if (message_mode)
 			message = trim(copytext(message, 3))
-			if (!(ishuman(src) || istype(src, /mob/living/simple_animal/parrot) || isrobot(src) && (message_mode=="department" || (message_mode in radiochannels))))
+			if (!(ishuman(src) || istype(src, /mob/living/simple_animal/parrot) || isrobot(src) && (message_mode=="department") || isAI(src) && (message_mode=="department") || (message_mode in radiochannels)))
 				message_mode = null //only humans can use headsets
 			// Check changed so that parrots can use headsets. Other simple animals do not have ears and will cause runtimes.
 			// And borgs -Sieve
@@ -247,6 +247,11 @@ var/list/department_radio_keys = list(
 					if(R.radio)//Sanityyyy
 						R.radio.talk_into(src, message, message_mode)
 						used_radios += R.radio
+				else if(isAI(src))//for the AI's radio.  This can't be with the borg thing above due to typecasting.
+					var/mob/living/silicon/ai/A = src
+					if(A.radio)
+						A.radio.talk_into(src, message, message_mode)
+						used_radios += A.radio
 				else
 					if (src:ears)
 						src:ears.talk_into(src, message, message_mode)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -29,6 +29,7 @@ var/list/ai_list = list()
 	var/icon/holo_icon//Default is assigned when AI is created.
 	var/obj/item/device/pda/ai/aiPDA = null
 	var/obj/item/device/multitool/aiMulti = null
+	var/obj/item/device/radio/headset/heads/ai_integrated/radio = null
 	var/obj/item/device/camera/ai_camera/aicamera = null
 
 	//MALFUNCTION
@@ -90,13 +91,16 @@ var/list/ai_list = list()
 	aiPDA.name = name + " (" + aiPDA.ownjob + ")"
 
 	aiMulti = new(src)
+	radio = new(src)
+	radio.myAi = src
 	aicamera = new/obj/item/device/camera/ai_camera(src)
 
 	if (istype(loc, /turf))
 		verbs.Add(/mob/living/silicon/ai/proc/ai_call_shuttle,/mob/living/silicon/ai/proc/ai_camera_track, \
 		/mob/living/silicon/ai/proc/ai_camera_list, /mob/living/silicon/ai/proc/ai_network_change, \
 		/mob/living/silicon/ai/proc/ai_statuschange, /mob/living/silicon/ai/proc/ai_hologram_change, \
-		/mob/living/silicon/ai/proc/toggle_camera_light, /mob/living/silicon/ai/proc/sensor_mode)
+		/mob/living/silicon/ai/proc/toggle_camera_light, /mob/living/silicon/ai/proc/sensor_mode, \
+		/mob/living/silicon/ai/proc/control_integrateed_radio)
 
 	if(!safety)//Only used by AIize() to successfully spawn an AI.
 		if (!B)//If there is no player/brain inside.
@@ -761,3 +765,12 @@ var/list/ai_list = list()
 	set name = "State Laws"
 
 	checklaws()
+
+/mob/living/silicon/ai/proc/control_integrateed_radio()
+	set name = "Radio Settings"
+	set desc = "Allows you to change settings of your radio."
+	set category = "AI Commands"
+
+	src << "Accessing Subspace Transceiver control..."
+	if (src.radio)
+		src.radio.interact(src)


### PR DESCRIPTION
I saw this get PR'd in the bay coder channel.  I had to steal it.  Remie asked me to get it.
And so I did.
After six hours+ of adapting say() to use it properly since they use a (i think better?) say() code.
Anyways, features;
The AI can use all the departmental channels without having to change intercoms.  AIs can also use ;.
AI can use radio while carded.  Humans can turn the radio on/off in the intellicard interface, just like wireless.
A verb is added to the AI so they can turn the radio frequency to something different for whatever reason or if it gets EMP'd.
The radio is dependent on telecomms to function, so intercoms still have a use, as well as for ntsl.
Binary is unaffected.
Original PR: https://github.com/Baystation12/Baystation12/pull/5638 by atlantiscze.
![example](http://puu.sh/adw1l/78acd3034f.png)
