### PR TITLE
Death to runtimes 2014

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -80,10 +80,11 @@ Note: Must be placed west/left of and R&D console to function.
 	if (shocked)
 		shock(user,50)
 	if (default_deconstruction_screwdriver(user, "protolathe_t", "protolathe", O))
-		if(linked_console)
-			linked_console.linked_lathe = null
-			linked_console = null
-		return
+		if(!busy)
+			if(linked_console)
+				linked_console.linked_lathe = null
+				linked_console = null
+			return
 
 	if(exchange_parts(user, O))
 		return


### PR DESCRIPTION
Fixes #732
Screwdrivering a busy protolathe should no longer runtime.
Huge thanks to SirBayer for his help. :+1: 
