### PR TITLE
Expanded Examine Experiment [DO NOT MERGE]

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -10,6 +10,9 @@
 	var/pass_flags = 0
 	var/throwpass = 0
 
+	var/desc_info = null //For the extended examination.  This is the blue 'tutorial text' that is on the second line.
+	var/desc_fluff = null //Ditto as above, but third line, golden letters and quotes, and is meant for fluff things.
+
 	///Chemistry.
 	var/datum/reagents/reagents = null
 
@@ -218,6 +221,23 @@ its easier to just keep the beam vertical.
 	usr << "\icon[src]That's \a [src]." //changed to "That's" from "This is" because "This is some metal sheets" sounds dumb compared to "That's some metal sheets" ~Carn
 	if(desc)
 		usr << desc
+		usr.desc_name_holder = src.name
+		usr.desc_holder = src.desc
+		usr.desc_info_holder = src.desc_info
+		usr.desc_fluff_holder = src.desc_fluff
+
+/*
+/obj/examine()
+	..()
+	if(src.desc_info)
+		usr.statpanel("Examine")
+		usr.stat("<font size='5'>\icon[src] [src.name]</font>")
+		usr.stat("[src.desc]")//stat(
+		usr.stat("<font color='#086A87'><b>[src.desc_info]</b></font>")
+		usr.stat("<font color='#B18904'><i>\"[src.desc_fluff]\"</i></font>")
+
+
+*/
 	// *****RM
 	//usr << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
 	return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -23,6 +23,10 @@
 	icon = 'icons/obj/doors/Doorint.dmi'
 	icon_state = "door_closed"
 	power_channel = ENVIRON
+	desc_info = "Airlocks can be hacked with a screwdriver, wirecutters, and a multitool. Pulsing different wires has different effects,\
+	 some of which are dangerous.  Silicons have greater control over the airlock.  They can be welded to keep them closed until they're unwelded."
+	desc_fluff = "The common Nanotrasen airlock has replaced doors entirely due to being (somewhat) secure, configurable,\
+	 and surprisingly cheap to build due to mass production of airlock circuits."
 
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -114,6 +114,8 @@
 /obj/structure/table
 	name = "table"
 	desc = "A square piece of metal standing on four metal legs. It can not move."
+	desc_info = "Use a wrench to deconstruct.  You can also pull players onto tables if you grab them."
+	desc_fluff = "A cold, metal table with four legs.  Unremarkable."
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "table"
 	density = 1
@@ -625,6 +627,7 @@ Destroy type values:
 /obj/structure/table/woodentable
 	name = "wooden table"
 	desc = "Do not apply fire to this. Rumour says it burns easily."
+	desc_fluff = "A nice looking wooden table.  Usually reserved for offices."
 	icon_state = "woodtable"
 	parts = /obj/item/weapon/table_parts/wood
 
@@ -632,6 +635,7 @@ Destroy type values:
 /obj/structure/table/woodentable/poker //No specialties, Just a mapping object.
 	name = "gambling table"
 	desc = "A seedy table for seedy dealings in seedy places."
+	desc_fluff = "Not many people know, but this table violates Nanotrasen regulation 48.B, where all green tables must be a certain shade of green."
 	icon_state = "pokertable"
 	parts = /obj/item/weapon/table_parts/wood/poker
 
@@ -641,6 +645,9 @@ Destroy type values:
 /obj/structure/table/reinforced
 	name = "reinforced table"
 	desc = "A version of the four legged table. It is stronger."
+	desc_info = "Use a welder, then wrench to deconstruct.  Otherwise the same as a normal table."
+	desc_fluff = "This kind of table is reinforced by having rods connecting the table to the floor.  Cutting the rods would\
+	 likely compromise it's integrity."
 	icon_state = "reinftable"
 	parts = /obj/item/weapon/table_parts/reinforced
 	var/status = 2
@@ -673,6 +680,7 @@ Destroy type values:
 /obj/structure/rack
 	name = "rack"
 	desc = "Different from the Middle Ages version."
+	desc_info = "Use a wrench to deconstruct."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "rack"
 	density = 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -614,6 +614,15 @@ var/list/slot_equipment_priority = list( \
 			add_stings_to_statpanel(mind.changeling.purchasedpowers)
 	add_spells_to_statpanel(mob_spell_list)
 
+	if(client)
+		statpanel("Examine")
+		stat("<font size='5'>[desc_name_holder]</font>")
+		stat("[desc_holder]")
+		if(desc_info_holder)
+			stat("<font color='#086A87'><b>[desc_info_holder]</b></font>")
+		if(desc_fluff_holder)
+			stat("<font color='#B18904'><i>\"[desc_fluff_holder]\"</i></font>")
+
 /mob/proc/add_spells_to_statpanel(var/list/spells)
 	for(var/obj/effect/proc_holder/spell/S in spells)
 		if(S.can_be_cast_by(src))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -621,7 +621,7 @@ var/list/slot_equipment_priority = list( \
 		if(desc_info_holder)
 			stat("<font color='#086A87'><b>[desc_info_holder]</b></font>")
 		if(desc_fluff_holder)
-			stat("<font color='#B18904'><i>\"[desc_fluff_holder]\"</i></font>")
+			stat("<font color='#B18904'><b>\"[desc_fluff_holder]\"</b></font>")
 
 /mob/proc/add_spells_to_statpanel(var/list/spells)
 	for(var/obj/effect/proc_holder/spell/S in spells)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -166,3 +166,9 @@
 	var/alien_talk_understand = 0
 
 	var/turf/listed_turf = null	//the current turf being examined in the stat panel
+
+
+	var/desc_name_holder = null
+	var/desc_holder = null
+	var/desc_info_holder = null
+	var/desc_fluff_holder = null

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/gun/energy/laser
 	name = "laser gun"
 	desc = "An energy-based laser gun that uses normal energy cells to fire concentrated beams of light that pass through glass and thin metal."
+	desc_info = "This gun can only fire lasers."
 	icon_state = "laser"
 	item_state = "laser"
 	w_class = 3.0
@@ -12,6 +13,8 @@
 /obj/item/weapon/gun/energy/laser/practice
 	name = "practice laser gun"
 	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."
+	desc_info = "This 'weapon' cannot harm anyone."
+	desc_fluff = "The focusing lens appears a bit dusty, and the actual laser has been modified to fire less potent bolts.  Unfortately, the modification can't be undone."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice)
 	clumsy_check = 0
 
@@ -19,11 +22,14 @@ obj/item/weapon/gun/energy/laser/retro
 	name ="retro laser"
 	icon_state = "retro"
 	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's private security or military forces. Nevertheless, it is still quite deadly and easy to maintain, making it a favorite amongst pirates and other outlaws."
-
+	desc_info = "This works just like the normal laser gun."
+	desc_fluff = "This model fell out of favor in the last few years due to the manufacturing cost, being out-phased with the equally powerful current laser gun."
 
 /obj/item/weapon/gun/energy/laser/captain
 	icon_state = "caplaser"
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
+	desc_info = "This gun can only fire lasers.  It self-recharges."
+	desc_fluff = "Most Captains are expected to own an antique in order to be regarded as prestigious among the other command staff.  A common choice is a gun, as it's both valuable and practical."
 	force = 10
 	origin_tech = null
 	var/charge_tick = 0
@@ -50,6 +56,9 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/weapon/gun/energy/laser/cyborg
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
+	desc_info = "This will use about one hundred units of charge per shot."
+	desc_fluff = "This laser has a wire running from where the power cell would be, to the cyborg's internal powercell.\
+	  Advanced cooling technologies allow continious fire without having to recharge, as long as the demand for energy is met."
 
 /obj/item/weapon/gun/energy/laser/cyborg/newshot()
 	if(isrobot(src.loc))
@@ -67,6 +76,8 @@ obj/item/weapon/gun/energy/laser/retro
 /obj/item/weapon/gun/energy/laser/scatter
 	name = "scatter laser gun"
 	desc = "A laser gun equipped with a refraction kit that spreads bolts."
+	desc_info = "This laser can fire 'spread bolts', like a shotgun."
+	desc_fluff = "This laser's lens was swapped with a refractive lens, causing light to spread and potentially wound multiple targets at great efficency."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/laser/scatter)
 
 	attack_self(mob/living/user as mob)
@@ -77,6 +88,7 @@ obj/item/weapon/gun/energy/laser/retro
 /obj/item/weapon/gun/energy/lasercannon
 	name = "laser cannon"
 	desc = "A heavier, experimental version of the common laser gun. The concentrated light is fired through a housing lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with less energy charge!"
+	desc_info = "This laser does twice the damage of a normal one."
 	icon_state = "lasercannon"
 	item_state = "laser"
 	origin_tech = "combat=4;materials=3;powerstorage=3"
@@ -86,6 +98,7 @@ obj/item/weapon/gun/energy/laser/retro
 /obj/item/weapon/gun/energy/xray
 	name = "xray laser gun"
 	desc = "A high-power laser gun capable of expelling concentrated xray blasts that pass through multiple soft targets and heavier materials."
+	desc_info = "This bolt pierces all mobs and certain structures."
 	icon_state = "xray"
 	item_state = "laser"
 	origin_tech = "combat=5;materials=3;magnets=2;syndicate=2"
@@ -98,6 +111,7 @@ obj/item/weapon/gun/energy/laser/retro
 	name = "laser tag gun"
 	icon_state = "bluetag"
 	desc = "A retro laser gun modified to fire harmless beams of light. Sound effects included!"
+	desc_info = "Requires wearing a laser tag vest to fire."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/bluetag)
 	origin_tech = "combat=1;magnets=2"
 	clumsy_check = 0
@@ -135,6 +149,7 @@ obj/item/weapon/gun/energy/laser/retro
 	name = "laser tag gun"
 	icon_state = "redtag"
 	desc = "A retro laser gun modified to fire harmless beams of light. Sound effects included!"
+	desc_info = "Requires wearing a laser tag vest to fire."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag)
 	origin_tech = "combat=1;magnets=2"
 	clumsy_check = 0

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -1,6 +1,8 @@
 /obj/item/weapon/gun/energy/taser
 	name = "taser gun"
 	desc = "A low-capacity, energy-based stun gun used by security teams to subdue targets at range."
+	desc_info = "This is used to stun people at a distance.  You get five shots with this one."
+	desc_fluff = "This stun gun has become the standard in Nanotrasen security teams due to it being very cheap to produce, while being effective (as long as you don't miss)."
 	icon_state = "taser"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
@@ -9,6 +11,8 @@
 /obj/item/weapon/gun/energy/taser/cyborg
 	name = "taser gun"
 	desc = "An integrated taser that draws directly from a cyborg's power cell. Used by security cyborgs and defense turrets to subdue humanoids at range. Integrated into the weapon is a limiter to prevent the cyborg's power cell from overheating."
+	desc_info = "This taser works like a normal one, except for the fact that it will recharge on it's own as long as you have it out."
+	desc_fluff = "A modified taser gun with the powercell removed.  A series of wires runs out of where the powercell would be, presumably transfering power from an external cell to the gun."
 	fire_sound = 'sound/weapons/Taser.ogg'
 	icon_state = "taser"
 	cell_type = "/obj/item/weapon/stock_parts/cell/secborg"
@@ -44,6 +48,9 @@
 /obj/item/weapon/gun/energy/stunrevolver
 	name = "stun revolver"
 	desc = "A high-tech revolver that fires disposable, compressed stun cartidges. The stun cartridges can be recharged using a conventional energy weapon recharger and their compact size allows for more shots over the standard taser before the cell needs recharging."
+	desc_info = "An upgrade to the taser, this is more efficent, resulting in more shots before recharging."
+	desc_fluff = "Originally, the designer of this weapon intended for it to work like a normal revolver, firing specialized shells that would deliver an electric shock.\
+	Due to the ammo being both expensive and a pain to reload, the designer decided to switch to rechargable stun cartidges."
 	icon_state = "stunrevolver"
 	origin_tech = "combat=3;materials=3;powerstorage=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/gun)
@@ -54,6 +61,7 @@
 /obj/item/weapon/gun/energy/crossbow
 	name = "mini energy crossbow"
 	desc = "A weapon favored by many syndicate stealth specialists."
+	desc_info = "This will stun a person and inflict minor toxin damage.  It will recharge itself slowly."
 	icon_state = "crossbow"
 	w_class = 2.0
 	item_state = "crossbow"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1690,6 +1690,8 @@ window "mapwindow"
 		on-size = ""
 		icon-size = 0
 		text-mode = false
+		letterbox = true
+		zoom = 0
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 		style = ""
@@ -2134,7 +2136,7 @@ window "infowindow"
 	elem "info"
 		type = INFO
 		pos = 0,0
-		size = 638x475
+		size = 636x451
 		anchor1 = 0,0
 		anchor2 = 100,100
 		font-family = ""
@@ -2157,9 +2159,11 @@ window "infowindow"
 		tab-font-family = ""
 		tab-font-size = 0
 		tab-font-style = ""
-		allow-html = false
+		allow-html = true
 		multi-line = true
 		on-show = ".winset\"rpane.infob.is-visible=true;rpane.browseb.is-visible=true?rpane.infob.pos=130,0:rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.browseb.is-visible=true?rpane.browseb.is-checked=true rpane.rpanewindow.left=browserwindow:rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
 		on-tab = ""
+		prefix-color = none
+		suffix-color = none
 


### PR DESCRIPTION
This morning I investigated tooltips.  Turns out, they technically are possible, but maptext ruins everything and it would look like ass and be shitty if you needed anything beyond a few words.

So I thought to myself, what could replace a tooltip?  And here we are.
This introduces a new tab, which is updated whenever you examine something normally.
It looks like this.
http://puu.sh/aj4EX/eeb58c0085.png
Blue line is for 'instructions' or tips, primarily aimed at new players.
The gold line is for fluff, if you want.  Go nuts, write paragraphs, as this is optional to read, in it's own tab and it won't clutter up the text.

You just need to add desc_info or desc_fluff and of course a string for it.
This is probably done poorly but it's more of an experiment then a feature right now.

Unfortunately there's a ton of writing to do to make this worthwhile but at least the framework is there!
(also if anyone can help me make it not use mob verbs to hold onto the thing, let me know.)
