### PR TITLE
Craftable Cigarette Packets [Good for Merge]

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -136,6 +136,7 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
 	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg), \
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
 	new/datum/stack_recipe("folder", /obj/item/weapon/folder), \
+	new/datum/stack_recipe("cigarette packet", /obj/item/weapon/storage/fancy/cigarettes/empty), \
 )
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -153,7 +153,7 @@
 	throwforce = 0
 	slot_flags = SLOT_BELT
 	storage_slots = 6
-	can_hold = list(/obj/item/clothing/mask/cigarette)
+	can_hold = list(/obj/item/clothing/mask/cigarette,/obj/item/weapon/match,/obj/item/weapon/lighter)
 	icon_type = "cigarette"
 
 /obj/item/weapon/storage/fancy/cigarettes/empty

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -156,6 +156,8 @@
 	can_hold = list(/obj/item/clothing/mask/cigarette)
 	icon_type = "cigarette"
 
+/obj/item/weapon/storage/fancy/cigarettes/empty
+
 /obj/item/weapon/storage/fancy/cigarettes/New()
 	..()
 	flags |= NOREACT


### PR DESCRIPTION
-Adds craftable empty Cigarette Packets that can be made with a sheet of cardboard.
-BONUS: Lighters and matches can be stored in cigarette packets
