### PR TITLE
Stolen Bugfixes... Attempt 2

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -148,7 +148,7 @@ for reference:
 		src.icon_state = "barrier[src.locked]"
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weapon/card/id/))
+		if (W.GetID())
 			if (src.allowed(user))
 				if	(src.emagged < 2.0)
 					src.locked = !src.locked

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -109,7 +109,7 @@
 						index2 -= message2_len
 				update_display(line1, line2)
 			if(4)				// supply shuttle timer
-				var/line1 = "SUPPLY"
+				var/line1 = "CARGO"
 				var/line2
 				if(supply_shuttle.moving)
 					line2 = get_supply_shuttle_timer()

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -18,7 +18,7 @@
 
 
 /obj/item/weapon/storage/lockbox/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/card/id))
+	if (W.GetID())
 		if(src.broken)
 			user << "\red It appears to be broken."
 			return

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -174,7 +174,7 @@
 
 
 /datum/song/Topic(href, href_list)
-	if(usr.canUseTopic(src))
+	if(!usr.canUseTopic(instrumentObj))
 		usr << browse(null, "window=instrument")
 		usr.unset_machine()
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -146,7 +146,10 @@
 	return 0
 
 /turf/proc/inertial_drift(atom/movable/A as mob|obj)
-	if(!(A.last_move))	return
+	if(!(A.last_move))
+		return
+	if (A.pulledby)
+		return
 	if((istype(A, /mob/) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
 		var/mob/M = A
 		if(M.Process_Spacemove(1))
@@ -154,7 +157,7 @@
 			return
 		spawn(5)
 			if((M && !(M.anchored) && (M.loc == src)))
-				if(M.inertia_dir)
+				if(M.inertia_dir & M.last_move)
 					step(M, M.inertia_dir)
 					return
 				M.inertia_dir = M.last_move

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -24,7 +24,7 @@
 
 		if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 			if(!ready)	output += "<p><a href='byond://?src=\ref[src];ready=1'>Declare Ready</A></p>"
-			else	output += "<p><b>You are ready</b> <a href='byond://?src=\ref[src];ready=2'>Cancel</A></p>"
+			else	output += "<p><b>You are ready</b> <a href='byond://?src=\ref[src];ready=0'>Cancel</A></p>"
 
 		else
 			output += "<a href='byond://?src=\ref[src];manifest=1'>Crew Manifest</A><br><br>"
@@ -95,7 +95,7 @@
 			return 1
 
 		if(href_list["ready"])
-			ready = !ready
+			ready = text2num(href_list["ready"])
 
 		if(href_list["refresh"])
 			src << browse(null, "window=playersetup") //closes the player setup window

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -350,11 +350,13 @@ var/const/GRAV_NEEDS_WRENCH = 3
 // Shake everyone on the z level to let them know that gravity was enagaged/disenagaged.
 /obj/machinery/gravity_generator/main/proc/shake_everyone()
 	var/turf/our_turf = get_turf(src)
-	for(var/mob/M in player_list)
+	for(var/mob/M in mob_list)
 		var/turf/their_turf = get_turf(M)
-		if(M.client && their_turf.z == our_turf.z)
-			shake_camera(M, 15, 1)
-			M.playsound_local(our_turf, 'sound/effects/alert.ogg', 100, 1, 0.5)
+		if(their_turf.z == our_turf.z)
+			M.update_gravity(M.mob_has_gravity())
+			if(M.client)
+				shake_camera(M, 15, 1)
+				M.playsound_local(our_turf, 'sound/effects/alert.ogg', 100, 1, 0.5)
 
 /obj/machinery/gravity_generator/main/proc/gravity_in_level()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
Sometimes git doesn't like me and bad things happen. So now we're on attempt 2.

Steals some bugfixes/tweaks from /tg/.
All the credit goes to whoever created the original PRs linked below (Still not sure why I left links to the original /tg/ PRs.)

Aranclanos's service borg violin fix: https://github.com/tgstation/-tg-station/pull/4030

Changed supply status display from SUPPLY to CARGO so the icon doesn't clip as much. Credit to Ikarrus. https://github.com/tgstation/-tg-station/pull/3933/files

Lockboxes can now be unlocked by a PDA with ID inside. Credit to LandoTheClimber. https://github.com/tgstation/-tg-station/pull/3978 (If you can think of other things that should be unlockable with a PDA, let me know)

Fixes the gravity generator not updating your gravity status. Credit to Giacom
https://github.com/tgstation/-tg-station/pull/3920

Fixes dead people floating in space randomly. Credit to Kelenius.
https://github.com/tgstation/-tg-station/pull/3980

Fixes spamming ready button toggling it. Credit to A-t48
https://github.com/tgstation/-tg-station/pull/4200

Also I just noticed I accidentally said "5-in-1"  in the commit instead of "6-in-1".... I'm good at counting
