### PR TITLE
Adds MediPen to 'survival' box (default spawn box)

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -56,6 +56,7 @@
 		sleep(1)
 		new /obj/item/clothing/mask/breath( src )
 		new /obj/item/weapon/tank/emergency_oxygen( src )
+		new /obj/item/weapon/reagent_containers/hypospray/medipen( src )
 		return
 
 /obj/item/weapon/storage/box/engineer

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -66,6 +66,7 @@
 		sleep(1)
 		new /obj/item/clothing/mask/breath( src )
 		new /obj/item/weapon/tank/emergency_oxygen/engi( src )
+		new /obj/item/weapon/reagent_containers/hypospray/medipen( src )
 		return
 
 /obj/item/weapon/storage/box/gloves


### PR DESCRIPTION
I added one MediPen to the default spawn box, in hopes that it helps when you discover a person in critical condition, so you can get them to appropriate medical care.
