### PR TITLE
Updates BYOND_MINOR and BYOND_MAJOR vars in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 language: c
 
 env:
-  BYOND_MAJOR="503"
-  BYOND_MINOR="1224"
+  BYOND_MAJOR="506"
+  BYOND_MINOR="1247"
 
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
Updates the BYOND_MINOR and BYOND_MAJOR environment variables in .travis.yml, so Travis will start compiling with BYOND 506.1247 instead of BYOND 503.1224.

I don't know if NTstation has a head maintainer or if there are head maintainers, but they should probably be the ones to make a descision about this.

---

_Made with the GitHub web editor._
