### PR TITLE
Ports a /TG/ camera menu improvement!

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -274,13 +274,13 @@
 		if("Show Camera List")
 			if(isAI(usr))
 				var/mob/living/silicon/ai/AI = usr
-				var/camera = input(AI) in AI.get_camera_list()
+				var/camera = input(AI, "Choose which camera you want to view", "Cameras") as null|anything in AI.get_camera_list()
 				AI.ai_camera_list(camera)
 
 		if("Track With Camera")
 			if(isAI(usr))
 				var/mob/living/silicon/ai/AI = usr
-				var/target_name = input(AI) in AI.trackable_mobs()
+				var/target_name = input(AI, "Choose who you want to track", "Tracking") as null|anything in AI.trackable_mobs()
 				AI.ai_camera_track(target_name)
 
 		if("Toggle Camera Light")

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -1,5 +1,7 @@
 /mob/living/silicon/ai/proc/get_camera_list()
 
+	track.cameras.Cut()
+
 	if(src.stat == 2)
 		return
 
@@ -10,32 +12,25 @@
 	camera_sort(L)
 
 	var/list/T = list()
-	T["Cancel"] = "Cancel"
+
 	for (var/obj/machinery/camera/C in L)
 		var/list/tempnetwork = C.network&src.network
 		if (tempnetwork.len)
 			T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
 
-	track = new()
 	track.cameras = T
 	return T
 
 
-/mob/living/silicon/ai/proc/ai_camera_list(var/camera in get_camera_list())
-	if(src.stat == 2)
-		src << "You can't list the cameras because you are dead!"
-		return
-
-	if (!camera || camera == "Cancel")
+/mob/living/silicon/ai/proc/ai_camera_list(var/camera)
+	if (!camera)
 		return 0
 
 	var/obj/machinery/camera/C = track.cameras[camera]
-	track = null
 	src.eyeobj.setLoc(C)
 
 	return
 
-// Used to allow the AI is write in mob names/camera name from the CMD line.
 /datum/trackable
 	var/list/names = list()
 	var/list/namecounts = list()
@@ -45,10 +40,14 @@
 
 /mob/living/silicon/ai/proc/trackable_mobs()
 
+	track.names.Cut()
+	track.namecounts.Cut()
+	track.humans.Cut()
+	track.others.Cut()
+
 	if(usr.stat == 2)
 		return list()
 
-	var/datum/trackable/TB = new()
 	for(var/mob/living/M in mob_list)
 		// Easy checks first.
 		// Don't detect mobs on Centcom. Since the wizard den is on Centcom, we only need this.
@@ -82,30 +81,30 @@
 			continue
 
 		var/name = M.name
-		if (name in TB.names)
-			TB.namecounts[name]++
-			name = text("[] ([])", name, TB.namecounts[name])
+		if (name in track.names)
+			track.namecounts[name]++
+			name = text("[] ([])", name, track.namecounts[name])
 		else
-			TB.names.Add(name)
-			TB.namecounts[name] = 1
+			track.names.Add(name)
+			track.namecounts[name] = 1
 		if(human)
-			TB.humans[name] = M
+			track.humans[name] = M
 		else
-			TB.others[name] = M
+			track.others[name] = M
 
-	var/list/targets = sortList(TB.humans) + sortList(TB.others)
-	src.track = TB
+	var/list/targets = sortList(track.humans) + sortList(track.others)
+
 	return targets
 
-/mob/living/silicon/ai/proc/ai_camera_track(var/target_name in trackable_mobs())
-	if(src.stat == 2)
-		src << "You can't track with camera because you are dead!"
-		return
+/mob/living/silicon/ai/verb/ai_camera_track(var/target_name as null|anything in trackable_mobs())
+	set name = "track"
+	set hidden = 1 //Do not display it on the verb lists. This verb exists purely so you can type "track Ian" to track him.
+
 	if(!target_name)
-		src.cameraFollow = null
+		return
 
 	var/mob/target = (isnull(track.humans[target_name]) ? track.others[target_name] : track.humans[target_name])
-	src.track = null
+
 	ai_actual_track(target)
 
 /mob/living/silicon/ai/proc/ai_actual_track(mob/living/target as mob)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -47,7 +47,7 @@ var/list/ai_list = list()
 	var/mob/living/silicon/ai/parent = null
 	var/camera_light_on = 0
 	var/list/obj/machinery/camera/lit_cameras = list()
-	var/datum/trackable/track = null
+	var/datum/trackable/track = new()
 
 	var/last_paper_seen = null
 	var/can_shunt = 1


### PR DESCRIPTION
Ports: https://github.com/tgstation/-tg-station/pull/4203
- This update features a Cancel button to the tracking and camera list
  input windows, allowing an AI to cancel a camera command.
- It also re-adds the ability to track from the command line. Type "Track
  Miku Frost" to stalk her relentlessly. (It will also auto-complete, so
  you can type "Track Saiga P" and a space so you do not have to know how
  to spell an entire name to input it).

Credit to MrPerson for the code. No issues noted in NTstation13 compatibility testing.
