### PR TITLE
Added changelog entry for adding the MediPen to the default spawn boxes

### DIFF
--- a/html/changelog.html
+++ b/html/changelog.html
@@ -58,6 +58,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 
 
+<div class='commit sansserif'>
+	<h2 class='date'>28 July 2014</h2>
+	<h3 class='author'>JJRcop updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>We have begun packaging MediPens inside your equipment boxes, because they are cheap, and we need to raise our expected survival rate, because we are losing recruits.
+		Please remember to use it <s>when</s> if you come across a crew member in critical condition. <u><b>Do not</b></u> use it if they are already dead, it doesn't work that way.
+		</li>
+	</ul>
+</div>
+
 
 <div class='commit sansserif'>
 	<h2 class='date'>6 July 2014</h2>


### PR DESCRIPTION
Little late, but I added an in character changelog entry for the MediPen being added to the default spawn boxes, since it may not be immediately apparent to everyone.
