### PR TITLE
Fix for /obj/item/weapon/storage/fancy/cigarcase/cohiba

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -219,6 +219,8 @@
 
 /obj/item/weapon/storage/fancy/cigarcase/cohiba/New()
 	..()
+	contents.Cut() // Fastfix. The old cigars will be garbage collected now.
+	
 	for(var/i=1; i <= storage_slots; i++)
 		new /obj/item/clothing/mask/cigarette/cigar/cohiba(src)
 	return


### PR DESCRIPTION
There was 7 regular cigars and 7 cohiba cigars in case, resulting in bluespace storage and broken icons. Fastfixed.
