### PR TITLE
Fixed #892

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -63,7 +63,11 @@
 /obj/item/weapon/gun/energy/update_icon()
 	var/ratio = power_supply.charge / power_supply.maxcharge
 	ratio = Ceiling(ratio*4) * 25
+
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
+	if(shot.e_cost > power_supply.charge)
+		ratio = 0
+
 	switch(modifystate)
 		if (0)
 			icon_state = "[initial(icon_state)][ratio]"


### PR DESCRIPTION
Energy guns and lasers now displaying "no charge" icon when charge < shot cost.
