### PR TITLE
Deathberry fix

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -282,9 +282,9 @@
 		..()
 		if(reagents)
 			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("toxin", 3+round(potency / 3, 1))
-			reagents.add_reagent("lexorin", 1+round(potency / 5, 1))
 			reagents.add_reagent("ehuadol", 2+round(potency / 5, 1))
+			reagents.add_reagent("lexorin", 1+round(potency / 5, 1))
+			reagents.add_reagent("toxin", 3+round(potency / 3, 1))
 			bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris


### PR DESCRIPTION
Thanks to YOSHMASTER for pointing this out to me. High potency death berries are now guaranteed to contain ehuadol.

This was previously not the case with high potency deathberries. Since the deathberry food item can only contain 50u, high potency deathberries would be filled entirely with toxin and lexorin, leaving no more space for ehuadol making the more potent deathberries actually less deadly than the lower potency ones.
