### PR TITLE
Fixes sql errors caused by odd and unexpected behavor in dbcon.Quote()

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -15,7 +15,8 @@
 
 // Run all strings to be used in an SQL query through this proc first to properly escape out injection attempts.
 /proc/sanitizeSQL(var/t as text)
-	return dbcon.Quote(t)
+	var/sqltext = dbcon.Quote(t);
+	return copytext(sqltext, 2, lentext(sqltext)-1);//Quote() adds quotes around input, we already do that
 
 /*
  * Text sanitization


### PR DESCRIPTION
the database helper function adds quotes to what you give it, but we already do that. rather then change every sql query to not use quotes, this seems like a better work around.

Fixes issues with library upload, and sql errors logging stats like deaths and rounds and what not. might fix others.
