### PR TITLE
Ports /tg/'s lower latejoiner antag cap with slight modifications

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -85,9 +85,10 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	return
 
 /datum/game_mode/changeling/make_antag_chance(var/mob/living/carbon/human/character) //Assigns changeling to latejoiners
-	if(changelings.len >= round(joined_player_list.len / config.changeling_scaling_coeff) + 1) //Caps number of latejoin antagonists
+	var/changelingcap = round(joined_player_list.len / config.changeling_scaling_coeff)
+	if(changelings.len >= changelingcap) //Caps number of latejoin antagonists
 		return
-	if (prob(100/config.changeling_scaling_coeff))
+	if(changelings.len <= (changelingcap - 2) || prob(100 / config.changeling_scaling_coeff))
 		if(character.client.prefs.be_special & BE_CHANGELING)
 			if(!jobban_isbanned(character.client, "changeling") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -86,7 +86,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/game_mode/changeling/make_antag_chance(var/mob/living/carbon/human/character) //Assigns changeling to latejoiners
 	var/changelingcap = round(joined_player_list.len / config.changeling_scaling_coeff)
-	if(changelings.len >= changelingcap) //Caps number of latejoin antagonists
+	if(changelings.len >= changelingcap + 1) //Caps number of latejoin antagonists
 		return
 	if(changelings.len <= (changelingcap - 1) || prob(100 / config.changeling_scaling_coeff))
 		if(character.client.prefs.be_special & BE_CHANGELING)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -88,7 +88,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	var/changelingcap = round(joined_player_list.len / config.changeling_scaling_coeff)
 	if(changelings.len >= changelingcap) //Caps number of latejoin antagonists
 		return
-	if(changelings.len <= (changelingcap - 2) || prob(100 / config.changeling_scaling_coeff))
+	if(changelings.len <= (changelingcap - 1) || prob(100 / config.changeling_scaling_coeff))
 		if(character.client.prefs.be_special & BE_CHANGELING)
 			if(!jobban_isbanned(character.client, "changeling") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -61,10 +61,11 @@
 	return
 
 /datum/game_mode/traitor/changeling/make_antag_chance(var/mob/living/carbon/human/character) //Assigns changeling to latejoiners
-	if(changelings.len >= round(joined_player_list.len / (config.changeling_scaling_coeff*2)) + 1) //Caps number of latejoin antagonists
+	var/changelingcap = round(joined_player_list.len / (config.changeling_scaling_coeff * 2))
+	if(changelings.len >= changelingcap) //Caps number of latejoin antagonists
 		..()
 		return
-	if (prob(100/(config.changeling_scaling_coeff*2)))
+	if(changelings.len <= (changelingcap - 2) || prob(100 / (config.changeling_scaling_coeff * 2)))
 		if(character.client.prefs.be_special & BE_CHANGELING)
 			if(!jobban_isbanned(character.client, "changeling") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -62,7 +62,7 @@
 
 /datum/game_mode/traitor/changeling/make_antag_chance(var/mob/living/carbon/human/character) //Assigns changeling to latejoiners
 	var/changelingcap = round(joined_player_list.len / (config.changeling_scaling_coeff * 2))
-	if(changelings.len >= changelingcap) //Caps number of latejoin antagonists
+	if(changelings.len >= changelingcap + 1) //Caps number of latejoin antagonists
 		..()
 		return
 	if(changelings.len <= (changelingcap - 1) || prob(100 / (config.changeling_scaling_coeff * 2)))

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -65,7 +65,7 @@
 	if(changelings.len >= changelingcap) //Caps number of latejoin antagonists
 		..()
 		return
-	if(changelings.len <= (changelingcap - 2) || prob(100 / (config.changeling_scaling_coeff * 2)))
+	if(changelings.len <= (changelingcap - 1) || prob(100 / (config.changeling_scaling_coeff * 2)))
 		if(character.client.prefs.be_special & BE_CHANGELING)
 			if(!jobban_isbanned(character.client, "changeling") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -85,9 +85,10 @@
 	return 1
 
 /datum/game_mode/traitor/make_antag_chance(var/mob/living/carbon/human/character) //Assigns traitor to latejoiners
-	if(traitors.len >= round(joined_player_list.len / (config.traitor_scaling_coeff * scale_modifier)) + 1) //Caps number of latejoin antagonists
+	var/traitorcap = round(joined_player_list.len / (config.traitor_scaling_coeff * scale_modifier))
+	if(traitors.len >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
-	if (prob(100/(config.traitor_scaling_coeff * scale_modifier)))
+	if(traitors.len <= (traitorcap - 2) || prob(100 / (config.traitor_scaling_coeff * scale_modifier)))
 		if(character.client.prefs.be_special & BE_TRAITOR)
 			if(!jobban_isbanned(character.client, "traitor") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -86,7 +86,7 @@
 
 /datum/game_mode/traitor/make_antag_chance(var/mob/living/carbon/human/character) //Assigns traitor to latejoiners
 	var/traitorcap = round(joined_player_list.len / (config.traitor_scaling_coeff * scale_modifier))
-	if(traitors.len >= traitorcap) //Upper cap for number of latejoin antagonists
+	if(traitors.len >= traitorcap + 1) //Upper cap for number of latejoin antagonists
 		return
 	if(traitors.len <= (traitorcap - 1) || prob(100 / (config.traitor_scaling_coeff * scale_modifier)))
 		if(character.client.prefs.be_special & BE_TRAITOR)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -88,7 +88,7 @@
 	var/traitorcap = round(joined_player_list.len / (config.traitor_scaling_coeff * scale_modifier))
 	if(traitors.len >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
-	if(traitors.len <= (traitorcap - 2) || prob(100 / (config.traitor_scaling_coeff * scale_modifier)))
+	if(traitors.len <= (traitorcap - 1) || prob(100 / (config.traitor_scaling_coeff * scale_modifier)))
 		if(character.client.prefs.be_special & BE_TRAITOR)
 			if(!jobban_isbanned(character.client, "traitor") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))


### PR DESCRIPTION
Lower cap code by Ikarrus!
There's some modifications by me aswell.

This should help make rounds less boring, especially with lots of latejoiners. If the ideal crewmember:antag ratio gets too low, the next latejoiner is guaranteed to become an antag. Works in traitor, traitorchan and changeling rounds.

My modifications are listed in the commits after the first one.
