### PR TITLE
[Needs poll] [Needs testing] blob changes for lowpop

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -11,7 +11,7 @@ var/list/blob_nodes = list()
 	config_tag = "blob"
 	antag_flag = BE_BLOB
 
-	required_players = 20
+	required_players = 17
 	required_enemies = 1
 	recommended_enemies = 1
 
@@ -24,9 +24,9 @@ var/list/blob_nodes = list()
 
 	var/cores_to_spawn = 1
 	var/players_per_core = 30
-	var/blob_point_rate = 3
+	var/blob_point_rate = 1.75
 
-	var/blobwincount = 350
+	var/blobwincount = 450
 
 	var/list/infected_crew = list()
 
@@ -34,6 +34,11 @@ var/list/blob_nodes = list()
 	cores_to_spawn = max(round(num_players()/players_per_core, 1), 1)
 
 	blobwincount = initial(blobwincount) * cores_to_spawn
+
+	if(num_players() >= 30)
+		blob_point_rate = 3
+	else if(num_players() >= 22)
+		blob_point_rate = 2.3
 
 	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing robots from the list

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -36,7 +36,7 @@ var/list/blob_nodes = list()
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
 	if(num_players() < 30)
-		blob_point_rate = min((num_players()*0.1)+(num_players()*0.006), 3)
+		blob_point_rate = min((num_players()*0.1)+0.1, 3)
 
 	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing robots from the list

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -36,7 +36,7 @@ var/list/blob_nodes = list()
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
 	if(num_players() < 30)
-		blob_point_rate = min((num_players()*0.1)+0.1, 3)
+		blob_point_rate = min((num_players()*0.1)+(0.4-((num_players()-17)/40)), 3)
 
 	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing robots from the list

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -35,10 +35,8 @@ var/list/blob_nodes = list()
 
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
-	if(num_players() >= 30)
-		blob_point_rate = 3
-	else if(num_players() >= 22)
-		blob_point_rate = 2.3
+	if(num_players() < 30)
+		blob_point_rate = min((num_players()*0.1)+(num_players()*0.006), 3)
 
 	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing robots from the list


### PR DESCRIPTION
Blobs can now occur with 17 players or more.

Blobs below 30 players get a lower resource rate. The rate is calculate like this:

Rate = (readied players/10)+(0.4-((readied players-17)/40)

So with 17 players you get a rate of 2.1, with 22 you have 2.475.
30+ player blobs keep their resource rate of 3.

Blobs also have to expand a bit more to win now. This should discourage hard-to-reach-without-AI locations such as xenobio or the AI sat which are a problem on lower pop rounds.
