### PR TITLE
Scroll through hair styles and facial hair

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -144,6 +144,26 @@ proc/listclearnulls(list/list)
 		pos--
 	L.Insert(pos+1, thing)
 
+// Returns the next item in a list
+/proc/next_list_item(var/item, var/list/L)
+	var/i
+	i = L.Find(item)
+	if(i == L.len)
+		i = 1
+	else
+		i++
+	return L[i]
+
+// Returns the previous item in a list
+/proc/previous_list_item(var/item, var/list/L)
+	var/i
+	i = L.Find(item)
+	if(i == 1)
+		i = L.len
+	else
+		i--
+	return L[i]
+
 /*
  * Sorting
  */

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -183,6 +183,7 @@ datum/preferences
 				dat += "<h3>Hair Style</h3>"
 
 				dat += "<a href='?_src_=prefs;preference=hair_style;task=input'>[hair_style]</a><BR>"
+				dat += "<a href='?_src_=prefs;preference=previous_hair_style;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_hair_style;task=input'>&gt;</a><BR>"
 				dat += "<span style='border:1px solid #161616; background-color: #[hair_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=hair;task=input'>Change</a><BR>"
 
 
@@ -191,6 +192,7 @@ datum/preferences
 				dat += "<h3>Facial Hair Style</h3>"
 
 				dat += "<a href='?_src_=prefs;preference=facial_hair_style;task=input'>[facial_hair_style]</a><BR>"
+				dat += "<a href='?_src_=prefs;preference=previous_facehair_style;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_facehair_style;task=input'>&gt;</a><BR>"
 				dat += "<span style='border: 1px solid #161616; background-color: #[facial_hair_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=facial;task=input'>Change</a><BR>"
 
 
@@ -598,6 +600,18 @@ datum/preferences
 						if(new_hair_style)
 							hair_style = new_hair_style
 
+					if("next_hair_style")
+						if (gender == MALE)
+							hair_style = next_list_item(hair_style, hair_styles_male_list)
+						else
+							hair_style = next_list_item(hair_style, hair_styles_female_list)
+
+					if("previous_hair_style")
+						if (gender == MALE)
+							hair_style = previous_list_item(hair_style, hair_styles_male_list)
+						else
+							hair_style = previous_list_item(hair_style, hair_styles_female_list)
+
 					if("facial")
 						var/new_facial = input(user, "Choose your character's facial-hair colour:", "Character Preference") as null|color
 						if(new_facial)
@@ -611,6 +625,18 @@ datum/preferences
 							new_facial_hair_style = input(user, "Choose your character's facial-hair style:", "Character Preference")  as null|anything in facial_hair_styles_female_list
 						if(new_facial_hair_style)
 							facial_hair_style = new_facial_hair_style
+
+					if("next_facehair_style")
+						if (gender == MALE)
+							facial_hair_style = next_list_item(facial_hair_style, facial_hair_styles_male_list)
+						else
+							facial_hair_style = next_list_item(facial_hair_style, facial_hair_styles_female_list)
+
+					if("previous_facehair_style")
+						if (gender == MALE)
+							facial_hair_style = previous_list_item(facial_hair_style, facial_hair_styles_male_list)
+						else
+							facial_hair_style = previous_list_item(facial_hair_style, facial_hair_styles_female_list)
 
 					if("underwear")
 						var/new_underwear


### PR DESCRIPTION
Adds < and > buttons to character setup screen to easily scroll to next
or previous hair style and facial hair, intead of opening the popup with
a long unsorted list.

Also adds two procs for returning the value of the previous or next index in a list.
