### PR TITLE
Save/Load

### DIFF
--- a/NTstation13.dme
+++ b/NTstation13.dme
@@ -741,6 +741,7 @@
 #include "code\modules\admin\verbs\possess.dm"
 #include "code\modules\admin\verbs\pray.dm"
 #include "code\modules\admin\verbs\randomverbs.dm"
+#include "code\modules\admin\verbs\savefiles_interface.dm"
 #include "code\modules\admin\verbs\ticklag.dm"
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"

--- a/NTstation13.dme
+++ b/NTstation13.dme
@@ -742,6 +742,7 @@
 #include "code\modules\admin\verbs\pray.dm"
 #include "code\modules\admin\verbs\randomverbs.dm"
 #include "code\modules\admin\verbs\savefiles_interface.dm"
+#include "code\modules\admin\verbs\savefiles_readwrite.dm"
 #include "code\modules\admin\verbs\ticklag.dm"
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -4,7 +4,7 @@
 */
 
 // 1 decisecond click delay (above and beyond mob/next_move)
-/mob/var/next_click	= 0
+/mob/var/tmp/next_click	= 0
 
 /*
 	Before anything else, defer these calls to a per-mobtype handler.  This allows us to

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -32,7 +32,7 @@ var/global/all_solved_wires = list() //Solved wire associative list, eg; all_sol
 	..()
 	src.holder = holder
 	if(!istype(holder, holder_type))
-		spawn(5) // No crashes when wires are loaded from savefiles
+		spawn(10) // No crashes when wires are loaded from savefiles
 			if(!istype(holder, holder_type))
 				CRASH("Our holder is null/the wrong type!")
 				return

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -12,7 +12,6 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 var/global/all_solved_wires = list() //Solved wire associative list, eg; all_solved_wires[/obj/machinery/door/airlock]
 
 /datum/wires
-
 	var/random = 0 // Will the wires be different for every single instance.
 	var/atom/holder = null // The holder
 	var/holder_type = null // The holder type; used to make sure that the holder is the correct type.
@@ -33,8 +32,10 @@ var/global/all_solved_wires = list() //Solved wire associative list, eg; all_sol
 	..()
 	src.holder = holder
 	if(!istype(holder, holder_type))
-		CRASH("Our holder is null/the wrong type!")
-		return
+		spawn(5) // No crashes when wires are loaded from savefiles
+			if(!istype(holder, holder_type))
+				CRASH("Our holder is null/the wrong type!")
+				return
 
 	// Generate new wires
 	if(random)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -6,7 +6,7 @@
 	var/list/fingerprintshidden
 	var/fingerprintslast = null
 	var/list/blood_DNA
-	var/last_bumped = 0
+	var/tmp/last_bumped = 0
 	var/pass_flags = 0
 	var/throwpass = 0
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,15 +1,15 @@
 /atom/movable
 	layer = 3
-	var/last_move = null
+	var/tmp/last_move = null
 	var/anchored = 0
 	var/move_speed = 10
-	var/l_move_time = 1
+	var/tmp/l_move_time = 1
 	var/m_flag = 1
-	var/throwing = 0
+	var/tmp/throwing = 0
 	var/throw_speed = 2
 	var/throw_range = 7
 	var/moved_recently = 0
-	var/mob/pulledby = null
+	var/tmp/mob/pulledby = null
 	glide_size = 8
 
 /atom/movable/Move()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -2,7 +2,7 @@
 	layer = 3
 	var/tmp/last_move = null
 	var/anchored = 0
-	var/move_speed = 10
+	var/tmp/move_speed = 10
 	var/tmp/l_move_time = 1
 	var/m_flag = 1
 	var/tmp/throwing = 0

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -9,7 +9,7 @@
 	throw_speed = 3
 	throw_range = 7
 	m_amt = 500
-	var/obj/item/weapon/disk/nuclear/the_disk = null
+	var/tmp/obj/item/weapon/disk/nuclear/the_disk = null
 	var/active = 0
 
 
@@ -66,8 +66,8 @@
 	icon = 'icons/obj/device.dmi'
 	desc = "A larger version of the normal pinpointer, this unit features a helpful quantum entanglement detection system to locate various objects that do not broadcast a locator signal."
 	var/mode = 0  // Mode 0 locates disk, mode 1 locates coordinates.
-	var/turf/location = null
-	var/obj/target = null
+	var/tmp/turf/location = null
+	var/tmp/obj/target = null
 
 	attack_self()
 		if(!active)
@@ -152,7 +152,7 @@
 
 /obj/item/weapon/pinpointer/nukeop
 	var/mode = 0	//Mode 0 locates disk, mode 1 locates the shuttle
-	var/obj/machinery/computer/syndicate_station/home = null
+	var/tmp/obj/machinery/computer/syndicate_station/home = null
 
 
 /obj/item/weapon/pinpointer/nukeop/attack_self(mob/user as mob)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -19,7 +19,7 @@ var/global/mulebot_count = 0
 	fire_dam_coeff = 0.7
 	brute_dam_coeff = 0.5
 	var/atom/movable/load = null		// the loaded crate (usually)
-	var/list/delivery_beacons = list() //List of beacons that serve as delivery locations.
+	var/tmp/list/delivery_beacons = list() //List of beacons that serve as delivery locations.
 	beacon_freq = 1400
 	control_freq = 1447
 	bot_type = MULE_BOT
@@ -27,7 +27,7 @@ var/global/mulebot_count = 0
 
 	suffix = ""
 
-	var/turf/target				// this is turf to navigate to (location of beacon)
+	var/tmp/turf/target				// this is turf to navigate to (location of beacon)
 	var/loaddir = 0				// this the direction to unload onto/load from
 	new_destination = ""	// pending new destination (waiting for beacon response)
 	destination = ""		// destination description

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -16,7 +16,7 @@
 	anchored = 1.0
 	var/start_active = 0 //If it ignores the random chance to start broken on round start
 	var/invuln = null
-	var/obj/item/device/camera_bug/bug = null
+	var/tmp/obj/item/device/camera_bug/bug = null
 	var/obj/item/weapon/camera_assembly/assembly = null
 
 	//OTHER

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -36,7 +36,7 @@
 	secondsElectrified = 0 //How many seconds remain until the door is no longer electrified. -1 if it is permanently electrified until someone fixes it.
 	var/aiDisabledIdScanner = 0
 	var/aiHacking = 0
-	var/obj/machinery/door/airlock/closeOther = null
+	var/tmp/obj/machinery/door/airlock/closeOther = null
 	var/closeOtherId = null
 	var/lockdownbyai = 0
 	var/doortype = 0

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1059,6 +1059,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/weapon/storage/box/PDAs
 	name = "spare PDAs"
 	desc = "A box of spare PDA microcomputers."
+	icon = 'icons/obj/storage.dmi'
 	icon_state = "pdabox"
 
 	New()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1059,7 +1059,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/weapon/storage/box/PDAs
 	name = "spare PDAs"
 	desc = "A box of spare PDA microcomputers."
-	icon = 'icons/obj/storage.dmi'
 	icon_state = "pdabox"
 
 	New()

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -16,7 +16,7 @@
 	m_amt = 50
 	g_amt = 20
 	origin_tech = "magnets=1;engineering=1"
-	var/obj/machinery/telecomms/buffer // simple machine buffer for device linkage
+	var/tmp/obj/machinery/telecomms/buffer // simple machine buffer for device linkage
 	hitsound = 'sound/weapons/tap.ogg'
 
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -21,7 +21,7 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 	var/broadcasting = 0
 	var/listening = 1
 	var/freerange = 0 // 0 - Sanitize frequencies, 1 - Full range
-	var/tmp/list/channels = list() //see communications.dm for full list. First channes is a "default" for :h
+	var/list/channels = list() //see communications.dm for full list. First channes is a "default" for :h
 	var/subspace_transmission = 0
 	var/syndie = 0//Holder to see if it's a syndicate encrpyed radio
 	var/maxf = 1499
@@ -40,8 +40,8 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 		//FREQ_BROADCASTING = 2
 
 /obj/item/device/radio
-	var/datum/radio_frequency/radio_connection
-	var/list/datum/radio_frequency/secure_radio_connections
+	var/tmp/datum/radio_frequency/radio_connection
+	var/tmp/list/datum/radio_frequency/secure_radio_connections
 
 	proc/set_frequency(new_frequency)
 		radio_controller.remove_object(src, frequency)

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/storage/bible
 	name = "bible"
-	desc = "To be applied to the head repeatedly."
+	desc = "Apply to head repeatedly."
 	icon_state ="bible"
 	throw_speed = 2
 	throw_range = 5
@@ -9,6 +9,10 @@
 	var/deity_name = "Christ"
 	interaction_sound = "pageturn"//bibles sound like paper when opening/dropping/picking up
 
+/obj/item/weapon/storage/bible/booze
+	name = "bible"
+	desc = "To be applied to the head repeatedly."
+	icon_state ="bible"
 
 /obj/item/weapon/storage/bible/booze/New()
 	..()

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/storage/bible
 	name = "bible"
-	desc = "Apply to head repeatedly."
+	desc = "To be applied to the head repeatedly."
 	icon_state ="bible"
 	throw_speed = 2
 	throw_range = 5
@@ -9,10 +9,6 @@
 	var/deity_name = "Christ"
 	interaction_sound = "pageturn"//bibles sound like paper when opening/dropping/picking up
 
-/obj/item/weapon/storage/bible/booze
-	name = "bible"
-	desc = "To be applied to the head repeatedly."
-	icon_state ="bible"
 
 /obj/item/weapon/storage/bible/booze/New()
 	..()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -49,20 +49,25 @@
 	qdel(src)
 
 
-/obj/item/weapon/storage/box/survival/New()
-	..()
-	contents = newlist(
-		/obj/item/clothing/mask/breath,
-		/obj/item/weapon/tank/emergency_oxygen,
-		/obj/item/weapon/reagent_containers/hypospray/medipen)
+/obj/item/weapon/storage/box/survival
+	New()
+		..()
+		contents = list()
+		sleep(1)
+		new /obj/item/clothing/mask/breath( src )
+		new /obj/item/weapon/tank/emergency_oxygen( src )
+		new /obj/item/weapon/reagent_containers/hypospray/medipen( src )
+		return
 
-/obj/item/weapon/storage/box/engineer/New()
-	..()
-	contents = newlist(
-		/obj/item/clothing/mask/breath,
-		/obj/item/weapon/tank/emergency_oxygen/engi,
-		/obj/item/weapon/reagent_containers/hypospray/medipen)
-
+/obj/item/weapon/storage/box/engineer
+	New()
+		..()
+		contents = list()
+		sleep(1)
+		new /obj/item/clothing/mask/breath( src )
+		new /obj/item/weapon/tank/emergency_oxygen/engi( src )
+		new /obj/item/weapon/reagent_containers/hypospray/medipen( src )
+		return
 
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"
@@ -99,7 +104,8 @@
 
 /obj/item/weapon/storage/box/syringes
 	name = "box of syringes"
-	desc = "A box full of syringes. A biohazard alert warning is printed on the box."
+	desc = "A box full of syringes."
+	desc = "A biohazard alert warning is printed on the box."
 	icon_state = "syringe"
 
 	New()
@@ -153,6 +159,20 @@
 		new /obj/item/weapon/dnainjector/m2h(src)
 		new /obj/item/weapon/dnainjector/m2h(src)
 		new /obj/item/weapon/dnainjector/m2h(src)
+
+/*/obj/item/weapon/storage/box/blanks	//Blanks removed, go home
+	name = "box of blank shells"
+	desc = "It has a picture of a gun and several warning symbols on the front."
+
+	New()
+		..()
+		new /obj/item/ammo_casing/shotgun/blank(src)
+		new /obj/item/ammo_casing/shotgun/blank(src)
+		new /obj/item/ammo_casing/shotgun/blank(src)
+		new /obj/item/ammo_casing/shotgun/blank(src)
+		new /obj/item/ammo_casing/shotgun/blank(src)
+		new /obj/item/ammo_casing/shotgun/blank(src)
+		new /obj/item/ammo_casing/shotgun/blank(src)*/
 
 /obj/item/weapon/storage/box/flashbangs
 	name = "box of flashbangs (WARNING)"
@@ -458,7 +478,7 @@
 	can_hold = list(/obj/item/toy/snappop)
 	New()
 		..()
-		while(contents.len < storage_slots)
+		for(var/i=1; i <= storage_slots; i++)
 			new /obj/item/toy/snappop(src)
 
 /obj/item/weapon/storage/box/matches
@@ -473,7 +493,7 @@
 
 	New()
 		..()
-		while(contents.len < storage_slots)
+		for(var/i=1; i <= storage_slots; i++)
 			new /obj/item/weapon/match(src)
 
 	attackby(obj/item/weapon/match/W as obj, mob/user as mob)
@@ -493,9 +513,11 @@
 
 /obj/item/weapon/storage/box/lights
 	name = "box of replacement bulbs"
+	icon = 'icons/obj/storage.dmi'
 	icon_state = "light"
 	desc = "This box is shaped on the inside so that only light tubes and bulbs fit."
 	item_state = "syringe_kit"
+	foldable = /obj/item/stack/sheet/cardboard //BubbleWrap
 	storage_slots=21
 	can_hold = list(/obj/item/weapon/light/tube, /obj/item/weapon/light/bulb)
 	max_combined_w_class = 21

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -49,25 +49,20 @@
 	qdel(src)
 
 
-/obj/item/weapon/storage/box/survival
-	New()
-		..()
-		contents = list()
-		sleep(1)
-		new /obj/item/clothing/mask/breath( src )
-		new /obj/item/weapon/tank/emergency_oxygen( src )
-		new /obj/item/weapon/reagent_containers/hypospray/medipen( src )
-		return
+/obj/item/weapon/storage/box/survival/New()
+	..()
+	contents = newlist(
+		/obj/item/clothing/mask/breath,
+		/obj/item/weapon/tank/emergency_oxygen,
+		/obj/item/weapon/reagent_containers/hypospray/medipen)
 
-/obj/item/weapon/storage/box/engineer
-	New()
-		..()
-		contents = list()
-		sleep(1)
-		new /obj/item/clothing/mask/breath( src )
-		new /obj/item/weapon/tank/emergency_oxygen/engi( src )
-		new /obj/item/weapon/reagent_containers/hypospray/medipen( src )
-		return
+/obj/item/weapon/storage/box/engineer/New()
+	..()
+	contents = newlist(
+		/obj/item/clothing/mask/breath,
+		/obj/item/weapon/tank/emergency_oxygen/engi,
+		/obj/item/weapon/reagent_containers/hypospray/medipen)
+
 
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"
@@ -104,8 +99,7 @@
 
 /obj/item/weapon/storage/box/syringes
 	name = "box of syringes"
-	desc = "A box full of syringes."
-	desc = "A biohazard alert warning is printed on the box."
+	desc = "A box full of syringes. A biohazard alert warning is printed on the box."
 	icon_state = "syringe"
 
 	New()
@@ -159,20 +153,6 @@
 		new /obj/item/weapon/dnainjector/m2h(src)
 		new /obj/item/weapon/dnainjector/m2h(src)
 		new /obj/item/weapon/dnainjector/m2h(src)
-
-/*/obj/item/weapon/storage/box/blanks	//Blanks removed, go home
-	name = "box of blank shells"
-	desc = "It has a picture of a gun and several warning symbols on the front."
-
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/blank(src)
-		new /obj/item/ammo_casing/shotgun/blank(src)
-		new /obj/item/ammo_casing/shotgun/blank(src)
-		new /obj/item/ammo_casing/shotgun/blank(src)
-		new /obj/item/ammo_casing/shotgun/blank(src)
-		new /obj/item/ammo_casing/shotgun/blank(src)
-		new /obj/item/ammo_casing/shotgun/blank(src)*/
 
 /obj/item/weapon/storage/box/flashbangs
 	name = "box of flashbangs (WARNING)"
@@ -478,7 +458,7 @@
 	can_hold = list(/obj/item/toy/snappop)
 	New()
 		..()
-		for(var/i=1; i <= storage_slots; i++)
+		while(contents.len < storage_slots)
 			new /obj/item/toy/snappop(src)
 
 /obj/item/weapon/storage/box/matches
@@ -493,7 +473,7 @@
 
 	New()
 		..()
-		for(var/i=1; i <= storage_slots; i++)
+		while(contents.len < storage_slots)
 			new /obj/item/weapon/match(src)
 
 	attackby(obj/item/weapon/match/W as obj, mob/user as mob)
@@ -513,11 +493,9 @@
 
 /obj/item/weapon/storage/box/lights
 	name = "box of replacement bulbs"
-	icon = 'icons/obj/storage.dmi'
 	icon_state = "light"
 	desc = "This box is shaped on the inside so that only light tubes and bulbs fit."
 	item_state = "syringe_kit"
-	foldable = /obj/item/stack/sheet/cardboard //BubbleWrap
 	storage_slots=21
 	can_hold = list(/obj/item/weapon/light/tube, /obj/item/weapon/light/bulb)
 	max_combined_w_class = 21

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -220,7 +220,7 @@
 /obj/item/weapon/storage/fancy/cigarcase/cohiba/New()
 	..()
 	contents.Cut() // Fastfix. The old cigars will be garbage collected now.
-	
+
 	for(var/i=1; i <= storage_slots; i++)
 		new /obj/item/clothing/mask/cigarette/cigar/cohiba(src)
 	return

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -15,8 +15,8 @@
 	var/max_w_class = 2 //Max size of objects that this object can store (in effect only if can_hold isn't set)
 	var/max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
 	var/storage_slots = 7 //The number of storage slots in this container.
-	var/obj/screen/storage/boxes = null
-	var/obj/screen/close/closer = null
+	var/tmp/obj/screen/storage/boxes = null
+	var/tmp/obj/screen/close/closer = null
 	var/use_to_pickup	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
 	var/display_contents_with_number	//Set this to make the storage item group contents of the same type and display them as a number.
 	var/allow_quick_empty	//Set this variable to allow the object to have the 'empty' verb, which dumps all the contents on the floor.

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -85,7 +85,9 @@ var/list/admin_verbs_fun = list(
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom,		/*allows us to spawn instances*/
-	/client/proc/respawn_character
+	/client/proc/respawn_character,
+	/client/proc/load_savefile,
+	/client/proc/load_savefile_to_turf
 	)
 var/list/admin_verbs_server = list(
 	/datum/admins/proc/startnow,
@@ -183,6 +185,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/cmd_debug_mob_lists,
 	/client/proc/cmd_debug_del_all,
 	/client/proc/enable_debug_verbs,
+	/client/proc/save_to_file,
 	/proc/possess,
 	/proc/release
 	)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -6,12 +6,14 @@ var/list/admin_datums = list()
 	var/client/owner	= null
 	var/fakekey			= null
 
-	var/datum/marked_datum
+	var/tmp/datum/marked_datum
 
 	var/admincaster_screen = 0	//See newscaster.dm under machinery for a full description
 	var/tmp/datum/feed_message/admincaster_feed_message = new /datum/feed_message   //These two will act as holders.
 	var/tmp/datum/feed_channel/admincaster_feed_channel = new /datum/feed_channel
 	var/admincaster_signature	//What you'll sign the newsfeeds as
+
+	var/tmp/savefile/savefile // Stores save file used by save files interface
 
 /datum/admins/New(datum/admin_rank/R, ckey)
 	if(!ckey)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -148,6 +148,7 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/print_pointers
 	src.verbs += /client/proc/count_movable_instances
 	src.verbs += /client/proc/SDQL2_query
+	src.verbs += /client/proc/save_to_file
 	//src.verbs += /client/proc/cmd_admin_rejuvenate
 
 	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/savefiles_interface.dm
+++ b/code/modules/admin/verbs/savefiles_interface.dm
@@ -1,4 +1,6 @@
 // Save/Load by ACCount
+// Two BYOND bugs was spotted and reported while working on this.
+
 
 /client/proc/save_to_file(var/atom/movable/A in world)
 	set category = "Debug"

--- a/code/modules/admin/verbs/savefiles_interface.dm
+++ b/code/modules/admin/verbs/savefiles_interface.dm
@@ -1,0 +1,97 @@
+/client/proc/save_to_file(var/atom/movable/A in world)
+	set category = "Debug"
+	set name = "Save To File"
+
+	if(!check_rights(R_DEBUG))	return
+
+	var/crash = alert("Are you sure you want to save [A]? THIS IS UNSAFE AND CAN CRASH THE SERVER! USE ON LOCAL SERVER ONLY!",
+	"Not For Ingame Use",
+	"NO!", "Yes")
+
+	if(crash != "Yes")
+		return
+
+	message_admins("[key_name(src)] is trying to crash the server with Save To File by saving [A]!")
+	log_admin("[key_name(src)] is trying to crash the server with Save To File by saving [A]!")
+
+	var/savefile/F = new()
+	var/txtfile = file("temp.sav")
+	F["save"] << A
+
+	fdel(txtfile)
+	F.ExportText("/", txtfile)
+	usr << ftp(txtfile, "[A.name].ss13")
+
+	usr << "Saved!"
+	fdel(txtfile)
+
+
+/atom/movable/Write()
+	fingerprints = null
+	fingerprintshidden = null
+	fingerprintslast = null
+	blood_DNA = null
+	suit_fibers = null
+	tag = null
+	..()
+
+
+/mob/Write()
+	lastattacker = null
+	lastattacked = null
+	attack_log = list()
+	..()
+
+
+/mob/living/carbon/human/Write()
+	overlays = list()
+	//overlays_standing = new/list(21)
+	..()
+	regenerate_icons()
+
+
+/mob/Read()
+	..()
+	regenerate_icons()
+
+
+/datum/wires/Read()
+
+/client/proc/load_savefile(F as file)
+	set category = "Debug"
+	set name = "Load Save File"
+
+	if(!check_rights(R_SPAWN))	return
+
+	var/txtfile = file("temp.sav")
+	fdel(txtfile)
+	fcopy(F,"temp.sav")
+	txtfile = file("temp.sav")
+
+	message_admins("[key_name(src)] has loaded a save file.")
+	log_admin("[key_name(src)] has loaded a save file.")
+
+	var/savefile/S = new()
+	S.ImportText("/", txtfile)
+	holder.savefile = S
+	fdel(txtfile)
+
+
+/client/proc/load_savefile_to_turf(var/turf/T in world)
+	set category = "Debug"
+	set name = "Spawn Save File Contents"
+
+	if(!check_rights(R_SPAWN))	return
+	if(!T)						return
+	if(!holder.savefile)		return
+
+	var/atom/movable/A
+	message_admins("[key_name(src)] is spawning a save file.")
+	log_admin("[key_name(src)] is spawning a save file.")
+	holder.savefile["save"] >> A
+	if(A)
+		A.Move(T)
+		A.loc = T
+
+		message_admins("[key_name(src)] has spawned a save file [A] ([A.type]) at [T.x], [T.y], [T.z].")
+		log_admin("[key_name(src)] has spawned a save file [A] ([A.type]) at [T.x], [T.y], [T.z].")

--- a/code/modules/admin/verbs/savefiles_interface.dm
+++ b/code/modules/admin/verbs/savefiles_interface.dm
@@ -1,3 +1,5 @@
+// Save/Load by ACCount
+
 /client/proc/save_to_file(var/atom/movable/A in world)
 	set category = "Debug"
 	set name = "Save To File"
@@ -26,36 +28,6 @@
 	fdel(txtfile)
 
 
-/atom/movable/Write()
-	fingerprints = null
-	fingerprintshidden = null
-	fingerprintslast = null
-	blood_DNA = null
-	suit_fibers = null
-	tag = null
-	..()
-
-
-/mob/Write()
-	lastattacker = null
-	lastattacked = null
-	attack_log = list()
-	..()
-
-
-/mob/living/carbon/human/Write()
-	overlays = list()
-	//overlays_standing = new/list(21)
-	..()
-	regenerate_icons()
-
-
-/mob/Read()
-	..()
-	regenerate_icons()
-
-
-/datum/wires/Read()
 
 /client/proc/load_savefile(F as file)
 	set category = "Debug"

--- a/code/modules/admin/verbs/savefiles_readwrite.dm
+++ b/code/modules/admin/verbs/savefiles_readwrite.dm
@@ -1,0 +1,96 @@
+// A lot of hacks to make stuff save/load correctly and keep save files small
+
+
+// Reduces save file size
+/atom/movable/Write(var/savefile/F)
+	..()
+	F.dir.Remove("tag", "suit_fibers", "blood_DNA",
+	"fingerprints", "fingerprintshidden", "fingerprintslast")
+
+	if(F["attack_verb"])
+		var/list/verbs = F["attack_verb"]
+		if(!verbs.len)
+			F.dir.Remove("attack_verb")
+
+/mob/Write(var/savefile/F)
+	..()
+	F.dir.Remove("attack_log", "lastattacker", "lastattacked")
+
+
+/obj/item/Write(var/savefile/F)
+	..()
+	if(!armor["melee"] && !armor["bullet"] && !armor["laser"] && !armor["energy"] && !armor["bomb"] && !armor["bio"] && !armor["rad"])
+		F.dir.Remove("armor")
+
+/obj/item/Read(var/savefile/F)
+	..()
+	if(!F["armor"])
+		armor = list("melee" = 0,"bullet" = 0,"laser" = 0,"energy" = 0,"bomb" = 0,"bio" = 0,"rad" = 0)
+
+
+/obj/item/weapon/Write(var/savefile/F)
+	..()
+	if((damtype == "fire" && hitsound == 'sound/items/welder.ogg') || (damtype == "brute" && hitsound == "swing_hit"))
+		F.dir.Remove("hitsound")
+
+
+// Reduces save file size and updates icons correctly
+/mob/living/carbon/human/Write(var/savefile/F)
+	..()
+	F.dir.Remove("overlays")
+
+/mob/Read()
+	..()
+	regenerate_icons()
+
+
+
+// Special roles save/load
+/datum/mind/Write(var/savefile/F)
+	..()
+	var/list/roles = list()
+
+	if(src in ticker.mode.changelings)
+		roles.Add("changeling")
+	if(src in ticker.mode.wizards)
+		roles.Add("wizard")
+	if(src in ticker.mode.cult)
+		roles.Add("cult")
+	if(src in ticker.mode.syndicates)
+		roles.Add("operative")
+	if(src in ticker.mode.head_revolutionaries)
+		roles.Add("head_rev")
+	if(src in ticker.mode.revolutionaries)
+		roles.Add("rev")
+	if(src in ticker.mode.traitors)
+		roles.Add("traitor")
+
+	if(roles.len)
+		F["roles"] << roles
+
+/datum/mind/Read(var/savefile/F)
+	..()
+	var/list/roles
+	F["roles"] >> roles
+
+	if(!roles || !roles.len )
+		return
+
+	for(var/role in roles)
+		switch(role)
+			if("changeling")
+				ticker.mode.changelings.Add(src)
+			if("wizard")
+				ticker.mode.wizards.Add(src)
+			if("cult")
+				ticker.mode.add_cultist(src)
+			if("operative")
+				ticker.mode.syndicates.Add(src)
+			if("rev")
+				ticker.mode.add_revolutionary(src)
+			if("head_rev")
+				ticker.mode.head_revolutionaries.Add(src)
+				ticker.mode.update_rev_icons_added(src)
+				ticker.mode.forge_revolutionary_objectives(src)
+			if("traitor")
+				ticker.mode.traitors.Add(src)

--- a/code/modules/admin/verbs/savefiles_readwrite.dm
+++ b/code/modules/admin/verbs/savefiles_readwrite.dm
@@ -51,6 +51,64 @@
 	regenerate_icons()
 
 
+// Removing block so badminspawned injectors will get updated block at New()
+/obj/item/weapon/dnainjector/Write(var/savefile/F)
+	..()
+	if(type != /obj/item/weapon/dnainjector) // Not a base type injector
+		F.dir.Remove("fields")
+
+
+// Resetting type to base type so contents will not be respawned twice
+/obj/item/weapon/storage/Write(var/savefile/F)
+	..()
+	var/list/base_simple = list(
+		/obj/item/weapon/storage/belt/utility,
+		/obj/item/weapon/storage/secure/safe,
+		/obj/item/weapon/storage/bible,
+		/obj/item/weapon/storage/belt/soulstone,
+		/obj/item/weapon/storage/belt/wands,
+		/obj/item/weapon/storage/wallet,
+		/obj/item/weapon/storage/backpack/satchel)
+
+	for(var/b_type in base_simple)
+		if(istype(src, b_type))
+			F["type"] << b_type
+
+/obj/item/weapon/storage/box/Write(var/savefile/F)
+	..()
+	if(type != /obj/item/weapon/storage/box) // Not a base type box
+		var/list/ignored_types = list(
+			/obj/item/weapon/storage/box/monkeycubes,
+			/obj/item/weapon/storage/box/matches,
+			/obj/item/weapon/storage/box/snappops)
+
+		if(!(type in ignored_types))
+			F["type"] << /obj/item/weapon/storage/box
+			F["name"] << name
+			F["desc"] << desc
+			F["icon_state"] << icon_state
+			F["storage_slots"] << storage_slots
+			F["max_combined_w_class"] << max_combined_w_class
+			F["use_to_pickup"] << use_to_pickup
+			F["w_class"] << w_class
+		else
+			F.dir.Remove("contents")
+
+
+/obj/item/weapon/storage/toolbox/Write(var/savefile/F)
+	..()
+	if(type != /obj/item/weapon/storage/toolbox) // Not a base type toolbox
+		var/list/ignored_types = list()
+
+		if(!(type in ignored_types))
+			F["type"] << /obj/item/weapon/storage/toolbox
+			F["name"] << name
+			F["desc"] << desc
+			F["icon_state"] << icon_state
+		else
+			F.dir.Remove("contents")
+
+
 // Removes mobs from blood's donor. We do not want to S/L the whole mob from blood syringe
 /datum/reagent/blood/Write(var/savefile/F)
 	var/donor = data["donor"]

--- a/code/modules/admin/verbs/savefiles_readwrite.dm
+++ b/code/modules/admin/verbs/savefiles_readwrite.dm
@@ -44,6 +44,14 @@
 	regenerate_icons()
 
 
+// Removes mobs from blood's donor. We do not want to S/L the whole mob from blood syringe
+/datum/reagent/blood/Write(var/savefile/F)
+	var/donor = data["donor"]
+	data["donor"] = null
+	..()
+	data["donor"] = donor
+
+
 
 // Special roles save/load
 /datum/mind/Write(var/savefile/F)

--- a/code/modules/admin/verbs/savefiles_readwrite.dm
+++ b/code/modules/admin/verbs/savefiles_readwrite.dm
@@ -1,4 +1,7 @@
-// A lot of hacks to make stuff save/load correctly and keep save files small
+// In this file:
+// * A lot of hacks to make stuff save/load correctly
+// * A lot of hacks to keep save files small
+// * A lot of hacks to stop server crashes on save
 
 
 // Reduces save file size
@@ -27,11 +30,15 @@
 	if(!F["armor"])
 		armor = list("melee" = 0,"bullet" = 0,"laser" = 0,"energy" = 0,"bomb" = 0,"bio" = 0,"rad" = 0)
 
-
 /obj/item/weapon/Write(var/savefile/F)
 	..()
 	if((damtype == "fire" && hitsound == 'sound/items/welder.ogg') || (damtype == "brute" && hitsound == "swing_hit"))
 		F.dir.Remove("hitsound")
+
+/obj/item/weapon/stock_parts/cell/Write(var/savefile/F)
+	..()
+	F.dir.Remove("overlays")
+
 
 
 // Reduces save file size and updates icons correctly
@@ -102,3 +109,19 @@
 				ticker.mode.forge_revolutionary_objectives(src)
 			if("traitor")
 				ticker.mode.traitors.Add(src)
+
+
+
+// Not save any vars for this items:
+
+// Because grabs are totally /tmp/ objects
+/obj/item/weapon/grab/Write(var/savefile/F)
+	return
+
+/obj/item/tk_grab/Write(var/savefile/F)
+	return
+
+// Because saving 50 boolets can trigger infinite loop check.
+// Boolets are respawned on New when magazine is loaded.
+/obj/item/ammo_box/magazine/m762/Write(var/savefile/F)
+	return

--- a/code/modules/admin/verbs/savefiles_readwrite.dm
+++ b/code/modules/admin/verbs/savefiles_readwrite.dm
@@ -51,6 +51,20 @@
 	regenerate_icons()
 
 
+// Resetting contents so contents will not be respawned twice
+/atom/Read(var/savefile/F)
+	..()
+	F["contents"] >> contents
+
+
+// Removing block so badminspawned injectors will get updated block at New()
+/obj/item/weapon/dnainjector/Write(var/savefile/F)
+	..()
+	if(type != /obj/item/weapon/dnainjector) // Not a base type injector
+		F.dir.Remove("fields")
+
+
+
 // Removes mobs from blood's donor. We do not want to S/L the whole mob from blood syringe
 /datum/reagent/blood/Write(var/savefile/F)
 	var/donor = data["donor"]

--- a/code/modules/admin/verbs/savefiles_readwrite.dm
+++ b/code/modules/admin/verbs/savefiles_readwrite.dm
@@ -51,64 +51,6 @@
 	regenerate_icons()
 
 
-// Removing block so badminspawned injectors will get updated block at New()
-/obj/item/weapon/dnainjector/Write(var/savefile/F)
-	..()
-	if(type != /obj/item/weapon/dnainjector) // Not a base type injector
-		F.dir.Remove("fields")
-
-
-// Resetting type to base type so contents will not be respawned twice
-/obj/item/weapon/storage/Write(var/savefile/F)
-	..()
-	var/list/base_simple = list(
-		/obj/item/weapon/storage/belt/utility,
-		/obj/item/weapon/storage/secure/safe,
-		/obj/item/weapon/storage/bible,
-		/obj/item/weapon/storage/belt/soulstone,
-		/obj/item/weapon/storage/belt/wands,
-		/obj/item/weapon/storage/wallet,
-		/obj/item/weapon/storage/backpack/satchel)
-
-	for(var/b_type in base_simple)
-		if(istype(src, b_type))
-			F["type"] << b_type
-
-/obj/item/weapon/storage/box/Write(var/savefile/F)
-	..()
-	if(type != /obj/item/weapon/storage/box) // Not a base type box
-		var/list/ignored_types = list(
-			/obj/item/weapon/storage/box/monkeycubes,
-			/obj/item/weapon/storage/box/matches,
-			/obj/item/weapon/storage/box/snappops)
-
-		if(!(type in ignored_types))
-			F["type"] << /obj/item/weapon/storage/box
-			F["name"] << name
-			F["desc"] << desc
-			F["icon_state"] << icon_state
-			F["storage_slots"] << storage_slots
-			F["max_combined_w_class"] << max_combined_w_class
-			F["use_to_pickup"] << use_to_pickup
-			F["w_class"] << w_class
-		else
-			F.dir.Remove("contents")
-
-
-/obj/item/weapon/storage/toolbox/Write(var/savefile/F)
-	..()
-	if(type != /obj/item/weapon/storage/toolbox) // Not a base type toolbox
-		var/list/ignored_types = list()
-
-		if(!(type in ignored_types))
-			F["type"] << /obj/item/weapon/storage/toolbox
-			F["name"] << name
-			F["desc"] << desc
-			F["icon_state"] << icon_state
-		else
-			F.dir.Remove("contents")
-
-
 // Removes mobs from blood's donor. We do not want to S/L the whole mob from blood syringe
 /datum/reagent/blood/Write(var/savefile/F)
 	var/donor = data["donor"]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -4,7 +4,7 @@
 	voice_name = "Unknown"
 	icon = 'icons/mob/human.dmi'
 	icon_state = "caucasian1_m_s"
-	var/list/hud_list = list()
+	var/tmp/list/hud_list = list()
 
 
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -78,10 +78,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 #define LEGCUFF_LAYER			3
 #define HANDS_LAYER				2
 #define FIRE_LAYER				1		//If you're on fire
-#define TOTAL_LAYERS			21		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
+#define TOTAL_LAYERS		21		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
 //////////////////////////////////
 /mob/living/carbon/human
-	var/list/overlays_standing[TOTAL_LAYERS]
+	var/tmp/list/overlays_standing[TOTAL_LAYERS]
 
 
 /mob/living/carbon/human/proc/apply_overlay(cache_index)
@@ -699,7 +699,7 @@ var/global/list/human_icon_cache = list()
 
 
 /mob/living/carbon/human
-	var/icon_render_key = ""
+	var/tmp/icon_render_key = ""
 
 
 ///////////////////////

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -16,7 +16,7 @@
 
 
 	var/hallucination = 0 //Directly affects how long a mob will hallucinate for
-	var/list/atom/hallucinations = list() //A list of hallucinated people that try to attack the mob. See /obj/effect/fake_attacker in hallucinations.dm
+	var/tmp/list/atom/hallucinations = list() //A list of hallucinated people that try to attack the mob. See /obj/effect/fake_attacker in hallucinations.dm
 
 
 	var/last_special = 0 //Used by the resist verb, likely used to prevent players from bypassing next_move by logging in/out.

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -7,29 +7,29 @@
 
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
 
-	var/obj/screen/flash = null
-	var/obj/screen/blind = null
-	var/obj/screen/hands = null
-	var/obj/screen/pullin = null
-	var/obj/screen/internals = null
-	var/obj/screen/oxygen = null
-	var/obj/screen/i_select = null
-	var/obj/screen/m_select = null
-	var/obj/screen/toxin = null
-	var/obj/screen/fire = null
-	var/obj/screen/bodytemp = null
-	var/obj/screen/healths = null
-	var/obj/screen/throw_icon = null
-	var/obj/screen/nutrition_icon = null
-	var/obj/screen/pressure = null
-	var/obj/screen/damageoverlay = null
+	var/tmp/obj/screen/flash = null
+	var/tmp/obj/screen/blind = null
+	var/tmp/obj/screen/hands = null
+	var/tmp/obj/screen/pullin = null
+	var/tmp/obj/screen/internals = null
+	var/tmp/obj/screen/oxygen = null
+	var/tmp/obj/screen/i_select = null
+	var/tmp/obj/screen/m_select = null
+	var/tmp/obj/screen/toxin = null
+	var/tmp/obj/screen/fire = null
+	var/tmp/obj/screen/bodytemp = null
+	var/tmp/obj/screen/healths = null
+	var/tmp/obj/screen/throw_icon = null
+	var/tmp/obj/screen/nutrition_icon = null
+	var/tmp/obj/screen/pressure = null
+	var/tmp/obj/screen/damageoverlay = null
 	/*A bunch of this stuff really needs to go under their own defines instead of being globally attached to mob.
 	A variable should only be globally attached to turfs/objects/whatever, when it is in fact needed as such.
 	The current method unnecessarily clusters up the variable list, especially for humans (although rearranging won't really clean it up a lot but the difference will be noticable for other mobs).
 	I'll make some notes on where certain variable defines should probably go.
 	Changing this around would probably require a good look-over the pre-existing code.
 	*/
-	var/obj/screen/zone_sel/zone_sel = null
+	var/tmp/obj/screen/zone_sel/zone_sel = null
 
 	var/damageoverlaytemp = 0
 	var/tmp/computer_id = null
@@ -42,7 +42,7 @@
 	var/sdisabilities = 0	//Carbon
 	var/disabilities = 0	//Carbon
 	var/tmp/atom/movable/pulling = null
-	var/next_move = null
+	var/tmp/next_move = null
 	var/notransform = null	//Carbon
 	var/hand = null
 	var/eye_blind = null	//Carbon
@@ -89,14 +89,14 @@
 	var/obj/structure/stool/bed/buckled = null//Living
 	var/obj/item/l_hand = null//Living
 	var/obj/item/r_hand = null//Living
-	var/obj/item/weapon/storage/s_active = null//Carbon
+	var/tmp/obj/item/weapon/storage/s_active = null//Carbon
 
 	var/seer = 0 //for cult//Carbon, probably Human
 	var/see_override = 0 //0 for no override, sets see_invisible = see_override in mob life process
 
-	var/datum/hud/hud_used = null
+	var/tmp/datum/hud/hud_used = null
 
-	var/list/grabbed_by = list(  )
+	var/tmp/list/grabbed_by = list(  )
 	var/list/requests = list(  )
 
 	var/list/mapobjs = list()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -85,7 +85,7 @@
 	var/shakecamera = 0
 	var/a_intent = "help"//Living
 	var/m_intent = "run"//Living
-	var/lastKnownIP = null
+	var/tmp/lastKnownIP = null
 	var/obj/structure/stool/bed/buckled = null//Living
 	var/obj/item/l_hand = null//Living
 	var/obj/item/r_hand = null//Living

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -146,7 +146,7 @@
 
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
-	var/update_icon = 1 //Set to 1 to trigger update_icons() at the next life() call
+	var/tmp/update_icon = 1 //Set to 1 to trigger update_icons() at the next life() call
 
 	var/status_flags = CANSTUN|CANWEAKEN|CANPARALYSE|CANPUSH	//bitflags defining which status effects can be inflicted (replaces canweaken, canstun, etc)
 

--- a/code/modules/nano/nanoexternal.dm
+++ b/code/modules/nano/nanoexternal.dm
@@ -40,4 +40,4 @@
 	return
 	
 // Used by the Nano UI Manager (/datum/nanomanager) to track UIs opened by this mob
-/mob/var/list/open_uis = list()
+/mob/var/tmp/list/open_uis = list()

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -16,7 +16,7 @@
 	dir = 1
 	var/strength_upper_limit = 2
 	var/interface_control = 1
-	var/list/obj/structure/particle_accelerator/connected_parts
+	var/tmp/list/obj/structure/particle_accelerator/connected_parts
 	var/assembled = 0
 	var/parts = null
 	var/datum/wires/particle_acc/control_box/wires = null

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -28,7 +28,7 @@
 	var/current = null
 	var/atom/original = null // the original target clicked
 	var/turf/starting = null // the projectile's starting turf
-	var/list/permutated = list() // we've passed through these atoms, don't try to hit them again
+	var/tmp/list/permutated = list() // we've passed through these atoms, don't try to hit them again
 
 	var/p_x = 16
 	var/p_y = 16 // the pixel location of the tile that the player clicked. Default is the center


### PR DESCRIPTION
You are a badmin, delaying the round, spawning a ton of items with custom names, armor vars, icons and contents for an event. And then some random bombgriefer ruins everything! And you need to restart a server, delay the round again and then spawn ton of items with custom names, icons, contents... 

Not anymore! With our brand new ShitSpawner 9000 you can spawn custom clothing, items, even mobs on your local server, save them, then load save files everywhere!
1. Set up local server.
2. Spawn!
3. Debug -> Debug Verbs
4. Click on item and select Save To File. (you can use lockers to save a ton of items at once)
5. Connect to server you want to fill with your ~~shi~~ spawn.
6. Debug  -> Load Save File
7. RMB on target turf -> Spawn Save File Contents

Save files can store everything you can spawn, including custom icons and custom onmob icons from my last badminpowers update.

Known troubles:
- Save To File is in Debug Verbs for a reason. It can crash server if you are trying to save item that has a ton of external referrences. Making external ref vars /tmp/ works, but i fixed only vars for mobs and items.
- Saving humans and items is totally safe, saving structures can be dangerous, saving atmos, telecomm and powernet machines will crash the server.
- Saving too many items at once triggers server's infinite loop check.
- Sideloaded icon referrenced multiple times loads incorrectly. BYOND's bug i think, see http://www.byond.com/forum/?post=1663894
