### PR TITLE
Meteor gun fires actual meteors

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -157,9 +157,15 @@
 		meteor_effect(heavy)
 		qdel(src)
 
-
 /obj/effect/meteor/ex_act()
 	return
+
+/obj/effect/meteor/Move()
+	. = ..()
+	if(loc == dest)
+		make_debris()
+		meteor_effect(heavy)
+		qdel(src)
 
 
 /obj/effect/meteor/proc/meteor_effect(var/sound=1)
@@ -209,6 +215,7 @@
 
 /obj/effect/meteor/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pickaxe))
+		make_debris()
 		qdel(src)
 		return
 	..()

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -35,3 +35,45 @@
 	name = "syringe gun spring"
 	desc = "A high-power spring that throws syringes."
 	projectile_type = null
+
+
+/obj/item/ammo_casing/energy/meteor
+	projectile_type = null
+	var/meteor_type = /obj/effect/meteor/medium
+	select_name = "meteor"
+
+/obj/item/ammo_casing/energy/meteor/throw_proj(var/turf/targloc, mob/living/user as mob|obj, params)
+	if (!istype(get_turf(targloc), /turf) || !istype(get_turf(user), /turf))
+		return 0
+	var/obj/effect/meteor/M = new meteor_type(get_turf(user))
+	M.dest = get_turf(targloc)
+	spawn(0)
+		walk_towards(M, M.dest, 1)
+	return 1
+
+/obj/item/ammo_casing/energy/meteor/ready_proj()
+	return
+
+/obj/item/ammo_casing/energy/meteor/big
+	meteor_type = /obj/effect/meteor/big
+	select_name = "big meteor"
+
+/obj/item/ammo_casing/energy/meteor/plasma
+	meteor_type = /obj/effect/meteor/flaming
+	select_name = "plasma meteor"
+
+/obj/item/ammo_casing/energy/meteor/irradiated
+	meteor_type = /obj/effect/meteor/irradiated
+	select_name = "radioactive meteor"
+
+/obj/item/ammo_casing/energy/meteor/meaty
+	meteor_type = /obj/effect/meteor/meaty
+	select_name = "meaty ore"
+
+/obj/item/ammo_casing/energy/meteor/meaty/xeno
+	meteor_type = /obj/effect/meteor/meaty/xeno
+	select_name = "xeno meaty ore"
+
+/obj/item/ammo_casing/energy/meteor/dust
+	meteor_type = /obj/effect/meteor/dust
+	select_name = "space dust"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -57,7 +57,11 @@
 	icon_state = "riotgun"
 	item_state = "c20r"
 	w_class = 4
-	ammo_type = list(/obj/item/ammo_casing/energy/meteor)
+	ammo_type = list(
+		/obj/item/ammo_casing/energy/meteor, /obj/item/ammo_casing/energy/meteor/big,
+		/obj/item/ammo_casing/energy/meteor/plasma, /obj/item/ammo_casing/energy/meteor/irradiated,
+		/obj/item/ammo_casing/energy/meteor/meaty, /obj/item/ammo_casing/energy/meteor/meaty/xeno,
+		/obj/item/ammo_casing/energy/meteor/dust)
 	cell_type = "/obj/item/weapon/stock_parts/cell/potato"
 	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
 	var/charge_tick = 0
@@ -78,6 +82,9 @@
 		charge_tick = 0
 		if(!power_supply) return 0
 		power_supply.give(100)
+
+	attack_self(mob/living/user as mob)
+		select_fire(user)
 
 	update_icon()
 		return


### PR DESCRIPTION
Meteor gun fires actual meteors instead of meteor proj. Meteor gun has egun-like modes now. You can fire any type of meteor from it, including space dust, meaty ore and xeno meaty ore.
