### PR TITLE
Light sabers finally glow in the dark

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -367,6 +367,7 @@
 	hitsound = "swing_hit"
 	flags = NOSHIELD
 	var/active = 0
+	var/f_lum = 1
 
 /obj/item/weapon/holo/esword/green
 	New()
@@ -396,6 +397,10 @@
 		hitsound = 'sound/weapons/blade1.ogg'
 		playsound(user, 'sound/weapons/saberon.ogg', 20, 1)
 		user << "<span class='warning'>[src] is now active.</span>"
+		if(src in user.contents)
+			user.AddLuminosity(f_lum)
+		else
+			SetLuminosity(f_lum)
 	else
 		force = 3
 		icon_state = "sword0"
@@ -403,7 +408,23 @@
 		hitsound = "swing_hit"
 		playsound(user, 'sound/weapons/saberoff.ogg', 20, 1)
 		user << "<span class='warning'>[src] can now be concealed.</span>"
+		if(src in user.contents)
+			user.AddLuminosity(-f_lum)
+		else
+			SetLuminosity(0)
 	return
+
+/obj/item/weapon/holo/esword/pickup(mob/user)
+	if(active)
+		SetLuminosity(0)
+		user.AddLuminosity(f_lum)
+
+/obj/item/weapon/holo/esword/dropped(mob/user)
+	if(active)
+		user.AddLuminosity(-f_lum)
+		SetLuminosity(f_lum)
+
+
 
 //BASKETBALL OBJECTS
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -308,11 +308,13 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "sword0"
 	item_state = "sword0"
+	item_color = "blue"
 	var/active = 0.0
 	w_class = 2.0
 	flags = NOSHIELD
 	attack_verb = list("attacked", "struck", "hit")
 	var/hacked = 0
+	var/f_lum = 1
 
 /obj/item/toy/sword/attack_self(mob/user as mob)
 	active = !( active )
@@ -320,18 +322,26 @@
 		user << "\blue You extend the plastic blade with a quick flick of your wrist."
 		playsound(user, 'sound/weapons/saberon.ogg', 20, 1)
 		if(hacked)
-			icon_state = "swordrainbow"
-			item_state = "swordrainbow"
+			item_color = "rainbow"
 		else
-			icon_state = "swordblue"
-			item_state = "swordblue"
+			item_color = "blue"
+		icon_state = "sword[item_color]"
+		item_state = "sword[item_color]"
 		w_class = 4
+		if(src in user.contents)
+			user.AddLuminosity(f_lum)
+		else
+			SetLuminosity(f_lum)
 	else
 		user << "\blue You push the plastic blade back down into the handle."
 		playsound(user, 'sound/weapons/saberoff.ogg', 20, 1)
 		icon_state = "sword0"
 		item_state = "sword0"
 		w_class = 2
+		if(src in user.contents)
+			user.AddLuminosity(-f_lum)
+		else
+			SetLuminosity(0)
 	add_fingerprint(user)
 	return
 
@@ -351,6 +361,10 @@
 			if(hacked) // That's right, we'll only check the "original" "sword".
 				newSaber.hacked = 1
 				newSaber.item_color = "rainbow"
+			else
+				newSaber.item_color = item_color
+			if(active)
+				user.AddLuminosity(-f_lum)
 			user.unEquip(W)
 			user.unEquip(src)
 			qdel(W)
@@ -366,6 +380,17 @@
 				user.update_inv_hands(0)
 		else
 			user << "<span class='warning'>It's already fabulous!</span>"
+
+/obj/item/toy/sword/pickup(mob/user)
+	if(active)
+		SetLuminosity(0)
+		user.AddLuminosity(f_lum)
+
+/obj/item/toy/sword/dropped(mob/user)
+	if(active)
+		user.AddLuminosity(-f_lum)
+		SetLuminosity(f_lum)
+	..()
 
 /*
  * Subtype of Double-Bladed Energy Swords

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -57,6 +57,7 @@
 	flags = NOSHIELD | SHARP
 	origin_tech = "magnets=3;syndicate=4"
 	var/hacked = 0
+	var/f_lum = 1
 
 /obj/item/weapon/melee/energy/sword/New()
 	item_color = pick("red", "blue", "green", "purple")
@@ -65,6 +66,16 @@
 	if(active)
 		return 1
 	return 0
+
+/obj/item/weapon/melee/energy/sword/pickup(mob/user)
+	if(active)
+		SetLuminosity(0)
+		user.AddLuminosity(f_lum)
+
+/obj/item/weapon/melee/energy/sword/dropped(mob/user)
+	if(active)
+		user.AddLuminosity(-f_lum)
+		SetLuminosity(f_lum)
 
 /obj/item/weapon/melee/energy/sword/attack_self(mob/living/user)
 	if (user.has_organic_effect(/datum/organic_effect/clumsy) && prob(50))
@@ -76,6 +87,10 @@
 		throwforce = 20
 		hitsound = 'sound/weapons/blade1.ogg'
 		attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+		if(src in user.contents)
+			user.AddLuminosity(f_lum)
+		else
+			SetLuminosity(f_lum)
 		if(istype(src,/obj/item/weapon/melee/energy/sword/pirate))
 			icon_state = "cutlass1"
 		else
@@ -88,6 +103,10 @@
 		throwforce = 5.0
 		hitsound = "swing_hit"
 		attack_verb = null
+		if(src in user.contents)
+			user.AddLuminosity(-f_lum)
+		else
+			SetLuminosity(0)
 		if(istype(src,/obj/item/weapon/melee/energy/sword/pirate))
 			icon_state = "cutlass0"
 		else
@@ -111,6 +130,10 @@
 			if(src.hacked) // That's right, we'll only check the "original" esword.
 				newSaber.hacked = 1
 				newSaber.item_color = "rainbow"
+			else
+				newSaber.item_color = item_color
+			if(active)
+				user.AddLuminosity(-f_lum)
 			user.unEquip(W)
 			user.unEquip(src)
 			qdel(W)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -26,6 +26,7 @@
 	var/force_wielded = 0
 	var/wieldsound = null
 	var/unwieldsound = null
+	var/f_lum = 2
 
 /obj/item/weapon/twohanded/proc/unwield()
 	wielded = 0
@@ -72,6 +73,11 @@
 		user << "<span class='notice'>You are now carrying the [name] with one hand.</span>"
 		if (src.unwieldsound)
 			playsound(src.loc, unwieldsound, 50, 1)
+		if (istype(src,/obj/item/weapon/twohanded/dualsaber/) || istype(src,/obj/item/weapon/twohanded/dualsaber/toy/))
+			if(src in user.contents)
+				user.AddLuminosity(-f_lum)
+			else
+				SetLuminosity(0)
 
 		var/obj/item/weapon/twohanded/offhand/O = user.get_inactive_hand()
 		if(O && istype(O))
@@ -86,6 +92,11 @@
 		user << "<span class='notice'>You grab the [initial(name)] with both hands.</span>"
 		if (src.wieldsound)
 			playsound(src.loc, wieldsound, 50, 1)
+		if (istype(src,/obj/item/weapon/twohanded/dualsaber/) || istype(src,/obj/item/weapon/twohanded/dualsaber/toy/))
+			if(src in user.contents)
+				user.AddLuminosity(f_lum)
+			else
+				SetLuminosity(f_lum)
 
 		var/obj/item/weapon/twohanded/offhand/O = new(user) ////Let's reserve his other hand~
 		O.name = "[initial(name)] - offhand"
@@ -277,6 +288,16 @@ obj/item/weapon/twohanded/
 		else
 			user << "<span class='warning'>It's starting to look like a triple rainbow - no, nevermind.</span>"
 
+/obj/item/weapon/twohanded/dualsaber/pickup(mob/user)
+	if(wielded) // This should never trigger as the dualsaber unwields on drop
+		SetLuminosity(0)
+		user.AddLuminosity(f_lum)
+	..()
+
+/obj/item/weapon/twohanded/dualsaber/dropped(mob/user)
+	if(wielded)
+		user.AddLuminosity(-f_lum)
+	..()
 
 //spears
 /obj/item/weapon/twohanded/spear


### PR DESCRIPTION
Energy swords are light sabers and light sabers glow in the dark. This
now also applies to spess station 13. Double e-swords will, of course, emit a little more light than normal e-swords because there are two of them.

Also, when making a double e-sword it will take the color of the original e-sword (the one you click on).

Preview:
![lighty-light-sabers gif](https://cloud.githubusercontent.com/assets/5267867/4100329/6aa5f24c-3090-11e4-8ff8-2366524c3815.gif)
(when I get very bright I use my PDA flashlight to be able to find the turned off swordhandles on the floor)
